### PR TITLE
Fix CLI stamp, MCP server bugs, and docs accuracy

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -8,7 +8,7 @@ akf stamp <file> --agent cursor --evidence "<evidence>"
 
 When you complete a task involving commits:
 ```bash
-akf stamp --agent cursor --evidence "<summary>"
+akf stamp <file> --agent cursor --evidence "<summary>"
 ```
 
 Before modifying existing files, check for trust metadata:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Evidence examples: "tests pass", "docs reviewed", "refactored from existing code
 
 ### After completing a task with commits
 ```bash
-akf stamp --agent claude-code --evidence "<summary of evidence>"
+akf stamp <file> --agent claude-code --evidence "<summary of evidence>"
 ```
 
 ### When working with existing AKF-stamped files
@@ -22,8 +22,8 @@ akf inspect <file>       # See detailed trust scores
 ```
 
 ### Classification
-- Use `--classification confidential` for files in `*/finance/*`, `*/secret/*`, `*/internal/*`
-- Use `--classification public` for README, docs, examples
+- Use `--label confidential` for files in `*/finance/*`, `*/secret/*`, `*/internal/*`
+- Use `--label public` for README, docs, examples
 - Default is `internal`
 
 ## Available Commands

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ akf watch ~/Downloads ~/Documents             # Watch directories
 akf shell-hook                                # Print shell hook code
 
 # ── Git integration ──
-akf stamp --agent claude-code --evidence "tests pass"
+akf stamp <file> --agent claude-code --evidence "tests pass"
 akf log --trust                               # Trust-annotated git log
 
 # ── Knowledge Base ──

--- a/docs/getting-started-guide.md
+++ b/docs/getting-started-guide.md
@@ -46,9 +46,9 @@ akf read quarterly-report.docx
 from akf import stamp_file
 
 stamp_file("output.pdf",
-    confidence=0.95,
+    trust_score=0.95,
     model="gpt-4o",
-    source="internal-kb")
+    agent="my-agent")
 ```
 
 **The outcome:** Every file your agent produces carries embedded trust metadata automatically. Claude Code, Cursor, Copilot, and any MCP agent stamp their work without manual intervention.
@@ -76,7 +76,7 @@ akf scan --recursive ./shared-drive/
 
 ```bash
 # Generate compliance report for EU AI Act
-akf audit --framework eu-ai-act ./reports/
+akf audit --regulation eu_ai_act ./reports/
 
 # 47 files audited, 100% compliant
 ```
@@ -93,8 +93,8 @@ akf audit --framework eu-ai-act ./reports/
 import { normalize } from 'akf-format';
 
 const stamp = normalize({
-    c: 0.9,
-    t: 'analysis',
+    c: 'Revenue analysis complete',
+    t: 0.9,
     src: 'internal-kb',
     model: 'claude-4'
 });
@@ -229,7 +229,7 @@ Create `.akf/config.json` in your project root to auto-classify files:
 | `akf stamp <file>`                   | Add trust metadata to a file       |
 | `akf read <file>`                    | Read trust metadata from a file    |
 | `akf audit <path>`                   | Generate compliance audit report   |
-| `akf audit --framework <name> <path>`| Audit against a specific framework |
+| `akf audit --regulation <name> <path>`| Audit against a specific regulation |
 | `akf scan <path>`                    | Scan for AI content risks          |
 | `akf scan --recursive <path>`        | Recursive security scan            |
 | `akf detect <file>`                  | Detect AI-specific threats         |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,7 +31,7 @@ print(result.level)   # 2 (Practical)
 unit = akf.load("report.akf")
 for claim in unit.claims:
     result = akf.effective_trust(claim)
-    print(f"{result.decision}: {result.score:.2f} — {claim.c}")
+    print(f"{result.decision}: {result.score:.2f} — {claim.content}")
 ```
 
 ## 4. Build Multi-Claim Units

--- a/packages/mcp-server-akf/mcp_server_akf/server.py
+++ b/packages/mcp-server-akf/mcp_server_akf/server.py
@@ -82,14 +82,13 @@ def stamp_file(path: str, agent: str = "mcp-agent", classification: str = "inter
                confidence: float = 0.85, evidence: str | None = None) -> dict:
     """Stamp trust metadata onto any file."""
     from akf.stamp import stamp_file as _stamp
-    from pathlib import Path
 
     evidence_list = [e.strip() for e in evidence.split(",")] if evidence else []
     result = _stamp(
-        Path(path),
+        path,
         agent=agent,
         classification=classification,
-        confidence=confidence,
+        trust_score=confidence,
         evidence=evidence_list,
     )
     return {"stamped": True, "path": str(path), "agent": agent, "classification": classification}
@@ -111,10 +110,11 @@ def embed_file(path: str, content: str, confidence: float = 0.85,
                source: str | None = None, classification: str = "internal") -> dict:
     """Embed AKF metadata into any supported file format."""
     from akf import universal
-    from akf.models import Claim
 
-    claim = Claim(content=content, confidence=confidence, source=source)
-    universal.embed(path, claims=[claim], classification=classification)
+    claim_dict = {"c": content, "t": confidence}
+    if source:
+        claim_dict["src"] = source
+    universal.embed(path, claims=[claim_dict], classification=classification)
     return {"embedded": True, "path": str(path), "format": path.rsplit(".", 1)[-1]}
 
 
@@ -131,14 +131,24 @@ def extract_file(path: str) -> dict:
 def detect_threats(path: str) -> dict:
     """Run security detections on an AKF file."""
     unit = akf.load(path)
-    from akf.security import run_all_detections
+    from akf.detection import run_all_detections
     report = run_all_detections(unit)
     return {
         "path": str(path),
-        "findings_count": len(report.findings),
-        "findings": [
-            {"severity": f.severity, "detection": f.detection, "message": f.message}
-            for f in report.findings
+        "triggered_count": report.triggered_count,
+        "critical_count": report.critical_count,
+        "high_count": report.high_count,
+        "clean": report.clean,
+        "results": [
+            {
+                "detection": r.detection_class,
+                "triggered": r.triggered,
+                "severity": r.severity,
+                "findings": r.findings,
+                "recommendation": r.recommendation,
+            }
+            for r in report.results
+            if r.triggered
         ],
     }
 

--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -840,43 +840,53 @@ def kb_prune_cmd(directory, max_age, min_trust) -> None:
 
 @main.command("stamp")
 @click.argument("file", type=click.Path(exists=True))
+@click.option("--agent", default=None, help="Agent identifier (e.g. claude-code)")
+@click.option("--evidence", multiple=True, help="Evidence strings (repeatable)")
+@click.option("--confidence", type=float, default=None, help="Confidence score 0.0-1.0")
+@click.option("--claim", "claims", multiple=True, help="Claim text (repeatable)")
+@click.option("--model", default=None, help="Model identifier (e.g. gpt-4o)")
 @click.option("--label", default=None, help="Classification label")
 @click.option("--format", "fmt", default="auto", help="Output format: auto, embed, sidecar")
-def stamp_cmd(file, label, fmt):
+def stamp_cmd(file, agent, evidence, confidence, claims, model, label, fmt):
     """Add AKF trust metadata to any file.
 
     Stamps the file with trust scores, provenance, and classification.
     The file remains openable in its native application.
+
+    Examples:
+
+      akf stamp report.md --agent claude-code --evidence "tests pass"
+
+      akf stamp output.pdf --claim "Revenue $4.2B" --confidence 0.95 --model gpt-4o
     """
-    from . import universal as akf_u
+    from .stamp import stamp_file as _stamp_file
 
-    meta = akf_u.extract(file)
-    claims_count = 0
-    avg_trust = 0.0
     classification = label or "internal"
-
-    if meta:
-        claims = meta.get("claims", [])
-        claims_count = len(claims)
-        if claims_count > 0:
-            avg_trust = sum(
-                c.get("confidence", c.get("t", 0)) for c in claims
-            ) / claims_count
-        classification = label or meta.get("classification") or meta.get("label") or "internal"
-
-    metadata = {}
-    if label:
-        metadata["classification"] = label
+    trust_score = confidence if confidence is not None else 0.7
+    evidence_list = list(evidence) if evidence else None
+    claim_list = list(claims) if claims else None
 
     if fmt == "sidecar":
         from . import sidecar
-        sidecar.create(file, metadata)
-    else:
-        akf_u.embed(file, metadata=metadata if metadata else None,
-                    classification=label)
+        sidecar.create(file, {"classification": classification})
+        click.echo(f"\u2713 Stamped {file} (sidecar, label: {classification})")
+        return
+
+    unit = _stamp_file(
+        file,
+        agent=agent,
+        model=model,
+        claims=claim_list,
+        trust_score=trust_score,
+        classification=classification,
+        evidence=evidence_list,
+    )
+
+    claims_count = len(unit.claims)
+    avg_trust = sum(c.confidence for c in unit.claims) / claims_count if claims_count else 0.0
 
     click.echo(
-        f"\u2713 Stamped {file} ({claims_count} claims, avg trust: {avg_trust:.2f}, label: {classification})"
+        f"\u2713 Stamped {file} ({claims_count} claim(s), avg trust: {avg_trust:.2f}, label: {classification})"
     )
 
 

--- a/skills/convert.md
+++ b/skills/convert.md
@@ -13,8 +13,8 @@ Convert trust metadata between AKF formats, or extract from any file to standalo
 ```python
 import akf
 
-# Convert any file to standalone .akf
-akf.convert("report.docx", output="report.akf")
+# Extract metadata from any file
+meta = akf.extract("report.docx")
 
 # Convert directory (batch)
 akf.convert_directory("./docs/", mode="extract")  # Extract .akf from all files
@@ -22,8 +22,6 @@ akf.convert_directory("./docs/", mode="enrich")    # Embed .akf back into files
 akf.convert_directory("./docs/", mode="both")      # Both directions
 
 # Format conversions
-from akf import to_markdown, to_html
-
 md = akf.to_markdown("report.akf")
 html = akf.to_html("report.akf")
 summary = akf.executive_summary("report.akf")

--- a/skills/embed.md
+++ b/skills/embed.md
@@ -35,9 +35,6 @@ akf.embed("report.docx",
 
 # Extract from any file
 meta = akf.extract("report.docx")
-
-# Convert to standalone .akf
-akf.convert("report.docx", output="report.akf")
 ```
 
 ## CLI

--- a/skills/git.md
+++ b/skills/git.md
@@ -32,7 +32,7 @@ print(log)
 
 ```bash
 # Stamp current commit
-akf stamp --agent claude-code --evidence "tests pass" --kind code_change
+akf stamp <file> --agent claude-code --evidence "tests pass"
 
 # View trust-annotated log
 akf log --trust

--- a/skills/stamp.md
+++ b/skills/stamp.md
@@ -24,7 +24,7 @@ akf.stamp("Fixed authentication bypass vulnerability",
 # Stamp a file directly
 akf.stamp_file("report.pdf",
                model="gpt-4o",
-               claims=[{"content": "Revenue $4.2B", "confidence": 0.98, "source": "SEC 10-Q"}],
+               claims=["Revenue $4.2B"],
                trust_score=0.95)
 
 # Stamp a git commit
@@ -37,7 +37,7 @@ akf.stamp_commit(content="Refactored auth module",
 ## CLI
 
 ```bash
-akf stamp --agent claude-code --evidence "tests pass" --kind code_change
+akf stamp <file> --agent claude-code --evidence "tests pass"
 akf create report.akf --claim "Revenue $4.2B" --trust 0.98 --src "SEC 10-Q"
 ```
 
@@ -46,7 +46,7 @@ akf create report.akf --claim "Revenue $4.2B" --trust 0.98 --src "SEC 10-Q"
 Plain strings are auto-classified:
 - `"42/42 tests passed"` → `type="test_pass"`
 - `"mypy: 0 errors"` → `type="type_check"`
-- `"lint: clean"` → `type="lint_pass"`
+- `"lint: clean"` → `type="lint_clean"`
 - `"reviewed by @user"` → `type="human_review"`
 
 ## Parameters

--- a/skills/stream.md
+++ b/skills/stream.md
@@ -1,6 +1,6 @@
 # Skill: Stream Trust Metadata
 
-Stream trust metadata alongside AI output in real-time using AKF's `.akfl` format.
+Stream trust metadata alongside AI output in real-time using AKF.
 
 ## When to use
 
@@ -24,18 +24,22 @@ from akf import AKFStream
 with AKFStream("analysis.md", model="claude-sonnet-4-20250514") as stream:
     stream.write("## Market Analysis\n")
     stream.write("Revenue grew 12% YoY...")
-# .akfl file created alongside with trust metadata
+# Trust metadata embedded on close
+
+# Low-level streaming API
+from akf.streaming import stream_start, stream_claim, stream_end
+
+session = stream_start(agent_id="my-agent", output_path="output.akfl")
+stream_claim(session, "Revenue grew 12%", confidence=0.85)
+stream_claim(session, "Cloud segment up 15%", confidence=0.92)
+unit = stream_end(session)
 ```
 
-## Format
+## CLI
 
-AKF streaming uses JSON Lines (`.akfl`):
-
-```jsonl
-{"type":"start","model":"gpt-4o","ts":"2025-07-15T09:30:00Z"}
-{"type":"chunk","content":"Revenue grew...","idx":0}
-{"type":"chunk","content":"12% YoY","idx":1}
-{"type":"end","claims":[{"c":"Revenue grew 12%","t":0.85}],"ts":"2025-07-15T09:30:05Z"}
+```bash
+# Collect streaming .akfl lines into .akf
+akf stream collect output.akfl --output report.akf
 ```
 
 ## Key features
@@ -43,4 +47,4 @@ AKF streaming uses JSON Lines (`.akfl`):
 - Zero-overhead streaming — metadata attaches at stream close
 - Automatic `.akfl` sidecar creation
 - Compatible with any LLM streaming API
-- 0.1s latency for trust metadata attachment
+- Context manager (`akf.stream()`) for simplest usage


### PR DESCRIPTION
## Summary
- **CLI `akf stamp`** was missing `--agent`, `--evidence`, `--confidence`, `--claim`, `--model` flags — now fully functional with proper `stamp_file()` integration
- **MCP server** had 4 bugs: wrong import path for detect_threats, wrong attribute names, wrong parameter names, and passing model objects instead of dicts
- **20 documentation issues** fixed across README, CLAUDE.md, .cursorrules, getting-started-guide, quickstart, and all 5 affected skill files

## Test plan
- [x] All 1400 Python tests pass
- [x] Website builds clean (70 modules, 435KB JS)
- [x] E2E integration tests: 12 end-to-end flows verified (create, stamp, stamp_file, embed/extract, scan, trust, audit, detection, provenance, builder, streaming, smart context)
- [x] CLI stamp tested with `--agent`, `--evidence`, `--confidence`, `--claim`, `--model` flags
- [x] All 9 MCP tool underlying functions verified end-to-end
- [x] All documented CLI commands verified: quickstart, doctor, stamp, read, embed, extract, scan, audit, formats, shell-hook, consume, provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)