### PR TITLE
Fix install experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ AI generates content → AKF stamps trust metadata → Anyone can verify it
 ```bash
 pip install akf    # Python
 npm install akf-format    # TypeScript / Node.js
+
+akf doctor         # Check your install — detects PATH issues and guides setup
 ```
 
-> **`akf` command not found?** Use `python3 -m akf` (always works), or:
+> **`akf` command not found?** Run `akf doctor` to auto-detect your setup, or use `python3 -m akf` (always works).
 > - Install with pipx: `pipx install akf` (recommended — auto-handles PATH)
-> - macOS: add `export PATH="$HOME/Library/Python/3.9/bin:$PATH"` to `~/.zshrc`
-> - Linux: add `export PATH="$HOME/.local/bin:$PATH"` to `~/.bashrc`
+> - **Windows:** use `python3 -m akf` or install via `pipx`
 
 ```python
 import akf

--- a/site/src/components/GetStartedPage.tsx
+++ b/site/src/components/GetStartedPage.tsx
@@ -223,6 +223,14 @@ export default function GetStartedPage() {
             <span className="text-border-subtle">|</span>
             <span>Having issues? <code className="text-accent font-mono">akf doctor</code></span>
           </div>
+          <div className="mt-4 mx-auto max-w-xl rounded-lg bg-surface-overlay border border-accent/20 p-3 flex items-start gap-3">
+            <svg className="w-5 h-5 text-accent shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+            </svg>
+            <p className="text-xs text-text-secondary leading-relaxed">
+              <strong className="text-text-primary">Troubleshooting:</strong> Run <code className="text-accent font-mono">akf doctor</code> first — it auto-detects your Python version, finds PATH issues, and tells you exactly what to fix.
+            </p>
+          </div>
         </section>
 
         {/* ── SECTION 2: Pick Your Path ── */}


### PR DESCRIPTION
## Summary
- Promote `akf doctor` in README quickstart section
- Simplify PATH troubleshooting — point to `akf doctor` instead of hardcoded paths
- Add prominent troubleshooting note on Get Started page

## Test plan
- [ ] README quickstart shows `akf doctor`
- [ ] PATH troubleshooting note is simplified
- [ ] GetStartedPage has prominent doctor reference