### PR TITLE
Fix website nav: add Validate link, Compare link, failure example

### DIFF
--- a/site/src/components/CertifyPage.tsx
+++ b/site/src/components/CertifyPage.tsx
@@ -60,6 +60,19 @@ const junitExample = `<!-- test-results.xml -->
   </testsuite>
 </testsuites>`;
 
+const failureExample = `$ akf certify quarterly-report.akf --min-trust 0.7
+
+CERTIFICATION FAILED
+
+  Trust Score:  0.32 (threshold: 0.70)
+  Detections:   1 critical, 2 warnings
+    CRITICAL  Ungrounded AI claim — no evidence for "revenue projection"
+    WARNING   Stale claim — "market share" last verified 180+ days ago
+    WARNING   Trust below threshold — 3 claims under 0.4
+
+  Files:    1 checked, 0 certified, 1 failed
+  Exit:     1`;
+
 const jsonEvidenceExample = `{
   "tests": { "passed": 42, "failed": 0 },
   "coverage": 87.5,
@@ -121,6 +134,18 @@ export default function CertifyPage() {
             <CodeBlock code={junitExample} filename="test-results.xml" />
             <CodeBlock code={jsonEvidenceExample} language="json" filename="evidence.json" />
           </div>
+        </section>
+
+        {/* What Failure Looks Like */}
+        <section className="mb-12">
+          <h2 className="text-xl font-bold text-text-primary mb-1">What Failure Looks Like</h2>
+          <p className="text-sm text-text-secondary mb-4">
+            When certification fails, AKF gives you an actionable breakdown — which claims are ungrounded, which evidence is stale, and exactly why the trust score fell short.
+          </p>
+          <CodeBlock code={failureExample} language="bash" filename="terminal" />
+          <p className="text-sm text-text-secondary mt-4">
+            A non-zero exit code lets CI pipelines catch untrusted content before it ships. Fix the flagged claims, re-run <code className="text-accent font-mono text-xs">akf certify</code>, and the gate turns green.
+          </p>
         </section>
 
         {/* CTA */}

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -7,6 +7,7 @@ export default function Footer() {
         <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
           <Link to="/validate" className="text-sm text-text-tertiary hover:text-text-primary transition-colors">Validate & Audit</Link>
           <Link to="/certify" className="text-sm text-text-tertiary hover:text-text-primary transition-colors">Certify</Link>
+          <Link to="/akf-vs-md" className="text-sm text-text-tertiary hover:text-text-primary transition-colors">Compare</Link>
           <Link to="/akf-vs-md" className="text-sm text-text-tertiary hover:text-text-primary transition-colors">AKF vs MD</Link>
           <Link to="/about" className="text-sm text-text-tertiary hover:text-text-primary transition-colors">About</Link>
         </div>

--- a/site/src/components/Navbar.tsx
+++ b/site/src/components/Navbar.tsx
@@ -57,6 +57,12 @@ export default function Navbar() {
             Certify
           </Link>
           <Link
+            to="/validate"
+            className="text-sm text-text-secondary hover:text-text-primary transition-colors hidden sm:inline"
+          >
+            Validate
+          </Link>
+          <Link
             to="/convert-to-akf"
             className="text-sm text-text-secondary hover:text-text-primary transition-colors hidden sm:inline"
           >


### PR DESCRIPTION
## Summary
- **Navbar.tsx**: Added missing "Validate" link to desktop nav (was only in mobile menu), placed between Certify and Convert to AKF
- **Footer.tsx**: Added "Compare" link pointing to `/akf-vs-md` between Certify and AKF vs MD
- **CertifyPage.tsx**: Added "What Failure Looks Like" section with a realistic failure output example and explanatory text, placed after Evidence Ingestion and before the CTA

## Test plan
- [ ] Verify desktop nav shows Validate link between Certify and Convert to AKF
- [ ] Verify footer shows Compare link between Certify and AKF vs MD
- [ ] Verify CertifyPage renders the failure example section with CodeBlock
- [ ] Verify mobile nav still works correctly