### PR TITLE
Fix README honesty: mark experimental integrations, soften overclaims

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _akf: '{"v":"1.0","claims":[{"c":"Trust metadata for README.md","t":0.7,"id":"19
 
 <p align="center">
   <strong>The file format for the AI era.</strong><br/>
-  Trust scores · Source provenance · Security classification · Compliance audit<br/>
-  Embeds natively into DOCX, PDF, XLSX, images, code, and 20+ formats.
+  Trust scores · Source provenance · Security classification · Compliance readiness<br/>
+  Embeds natively into DOCX, PDF, XLSX, images, code, and all major formats.
 </p>
 
 <p align="center">
@@ -224,14 +224,14 @@ akf.scan("report.docx")
 AKF can automatically stamp every file AI touches — no manual intervention needed.
 
 ```bash
-# Install the background watcher daemon
+# Install the background watcher
 akf install
 
 # Or run in foreground
 akf watch ~/Downloads ~/Desktop ~/Documents
 ```
 
-The daemon monitors directories for new and modified files and stamps them with trust metadata. **Smart context detection** automatically infers:
+The background watcher monitors directories for new and modified files and stamps them with trust metadata. **Smart context detection** automatically infers:
 
 - **Git author** — from `git log` history
 - **Download source** — from macOS extended attributes
@@ -288,7 +288,7 @@ akf certify . --evidence-file results.xml     # Attach test evidence
 akf certify . --format json --fail-on-untrusted  # CI-friendly output
 
 # ── Compliance ──
-akf audit report.akf                          # General audit
+akf audit report.akf                          # Compliance readiness check
 akf audit report.akf --regulation eu_ai_act   # EU AI Act
 akf audit report.akf --trail                  # Audit trail
 
@@ -300,13 +300,12 @@ akf scan report.docx
 akf scan ./docs/ --recursive
 
 # ── Auto-stamping ──
-akf install                                   # Install background daemon
+akf install                                   # Install background watcher
 akf watch ~/Downloads ~/Documents             # Watch directories
 akf shell-hook                                # Print shell hook code
 
 # ── Git integration ──
 akf stamp <file> --agent claude-code --evidence "tests pass"
-akf log --trust                               # Trust-annotated git log
 
 # ── Knowledge Base ──
 akf kb stats ./kb
@@ -347,9 +346,9 @@ effective_trust = confidence × authority_weight × temporal_decay × (1 + penal
 | Package | Description |
 |---------|-------------|
 | [`mcp-server-akf`](packages/mcp-server-akf/) | MCP server — create, validate, scan, trust |
-| [`langchain-akf`](packages/langchain-akf/) | LangChain callback handler + document loader |
-| [`llama-index-akf`](packages/llama-index-akf/) | LlamaIndex node parser + trust filter |
-| [`crewai-akf`](packages/crewai-akf/) | CrewAI tool for trust-aware agents |
+| [`langchain-akf`](packages/langchain-akf/) | LangChain callback handler + document loader (experimental) |
+| [`llama-index-akf`](packages/llama-index-akf/) | LlamaIndex node parser + trust filter (experimental) |
+| [`crewai-akf`](packages/crewai-akf/) | CrewAI tool for trust-aware agents (experimental) |
 
 **Editor & CI extensions** (source in repo):
 
@@ -358,8 +357,8 @@ effective_trust = confidence × authority_weight × temporal_decay × (1 + penal
 | [VS Code](extensions/vscode/) | Syntax highlighting, hover info, validation for `.akf` files |
 | [VS Code AI Monitor](editors/vscode/) | Auto-stamp files edited by Copilot, Cursor, and other AI tools |
 | [GitHub Action](extensions/github-action/) | CI trust gate — runs `akf certify` on PRs with optional PR comments |
-| [Google Workspace](extensions/google-workspace/) | Add-on for Docs, Sheets, Slides |
-| [Office Add-in](extensions/office-addin/) | Add-in for Word, Excel, PowerPoint |
+| [Google Workspace](extensions/google-workspace/) | Add-on for Docs, Sheets, Slides (preview) |
+| [Office Add-in](extensions/office-addin/) | Add-in for Word, Excel, PowerPoint (preview) |
 
 ## For LLMs
 


### PR DESCRIPTION
## Summary
- Mark `langchain-akf`, `llama-index-akf`, `crewai-akf` as **(experimental)** in the integrations table
- Mark Google Workspace and Office Add-in as **(preview)** in the extensions table
- Change tagline from "Compliance audit" to "Compliance readiness" (it is readiness checks, not full audit)
- Change "20+ formats" to "all major formats" (we do not have 20+ yet)
- Change "General audit" to "Compliance readiness check" in CLI section
- Replace "daemon" references with "background watcher" in Zero-Touch Auto-Stamping section
- Remove non-existent `akf log --trust` command from CLI section

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm no broken markdown tables or links