### PR TITLE
Align TypeScript SDK version to 1.1.0

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akf-format",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AKF — Agent Knowledge Format SDK for TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps `akf-format` npm package version from `1.0.0` to `1.1.0` to match the Python SDK release
- The AKF wire-format version (`v: "1.0"`) is unchanged -- only the SDK package version is updated

## Test plan
- [ ] Verify `typescript/package.json` shows version `1.1.0`
- [ ] Run `npm run test` in `typescript/` to confirm no regressions
- [ ] Confirm Python SDK version (`python/akf/__init__.py`) matches at `1.1.0`