### PR TITLE
Fix CI test assertions for new scan output format

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -43,7 +43,7 @@ office = ["python-docx>=0.8", "openpyxl>=3.1", "python-pptx>=0.6"]
 report = ["fpdf2>=2.7"]
 crypto = ["cryptography>=42.0"]
 all = ["python-docx>=0.8", "openpyxl>=3.1", "python-pptx>=0.6", "pypdf>=3.0", "Pillow>=10.0", "cryptography>=42.0", "fpdf2>=2.7"]
-dev = ["pytest", "black", "ruff"]
+dev = ["pytest", "black", "ruff", "pyyaml"]
 
 [project.scripts]
 akf = "akf.cli:main"

--- a/python/tests/test_e2e_integration.py
+++ b/python/tests/test_e2e_integration.py
@@ -489,17 +489,17 @@ class TestPhase5Scan:
     def test_scan_directory(self):
         d = str(Path(TEST_DIR) / "markdown")
         rc, out, _ = akf("scan", d, "-r")
-        assert "Scanned" in out
-        assert "AKF-enriched" in out
+        assert "scanned" in out
+        assert "enriched" in out
 
     def test_scan_full_tree(self):
         rc, out, _ = akf("scan", TEST_DIR, "-r")
-        assert "Scanned" in out
+        assert "scanned" in out
 
     def test_scan_nested_recursive(self):
         d = str(Path(TEST_DIR) / "nested")
         rc, out, _ = akf("scan", d, "-r")
-        assert "Scanned" in out
+        assert "scanned" in out
 
 
 # ---------------------------------------------------------------------------
@@ -1050,10 +1050,10 @@ class TestPhase14Volume:
     def test_scan_entire_tree(self):
         """Scan the full test directory tree."""
         rc, out, _ = akf("scan", TEST_DIR, "-r")
-        assert "Scanned" in out
-        # Parse the count
+        assert "scanned" in out
+        # Parse the count from new box format: "X scanned"
         import re
-        m = re.search(r"Scanned (\d+) files", out)
+        m = re.search(r"(\d+) scanned", out)
         assert m and int(m.group(1)) > 20
 
 


### PR DESCRIPTION
## Summary
- Update e2e scan tests to match new structured box output (`"scanned"` instead of `"Scanned"`)
- Add `pyyaml` to dev dependencies (fixes `ModuleNotFoundError: No module named 'yaml'` in certify tests)

Fixes the CI failures from the v1.2.0 publish pipeline.

## Test plan
- [x] `pytest tests/test_cli.py tests/test_report.py` — 89 passed
- [ ] CI pipeline passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)