### PR TITLE
Fix publish workflow: add contents:read for private repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      contents: read   # checkout private repo
       id-token: write  # for PyPI trusted publishing (OIDC)
     steps:
       - uses: actions/checkout@v4
@@ -69,6 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      contents: read   # checkout private repo
       id-token: write  # for npm trusted publishing (OIDC provenance)
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Add `contents: read` permission to publish-python and publish-typescript jobs. Without this, the `release` environment's restricted GITHUB_TOKEN can't checkout the private repo, causing "Repository not found" during `actions/checkout`.

## Test plan
- [ ] Re-tag v1.2.0 after merge and verify publish pipeline passes checkout step

🤖 Generated with [Claude Code](https://claude.com/claude-code)