### PR TITLE
Release v1.2.1 — npm README and CHANGELOG

### DIFF
--- a/python/akf/__init__.py
+++ b/python/akf/__init__.py
@@ -278,7 +278,7 @@ def read(filepath):
         return meta
 
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __all__ = [
     # Models
     "AKF",

--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -15,7 +15,7 @@ from .trust import compute_all, effective_trust
 
 
 @click.group(invoke_without_command=True)
-@click.version_option(version="1.2.0", prog_name="akf")
+@click.version_option(version="1.2.1", prog_name="akf")
 @click.pass_context
 def main(ctx) -> None:
     """AKF — Agent Knowledge Format CLI."""

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "akf"
-version = "1.2.0"
+version = "1.2.1"
 description = "AKF — Agent Knowledge Format. Lightweight file format for AI-generated knowledge with built-in trust, provenance, and security."
 requires-python = ">=3.9"
 authors = [

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akf-format",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AKF — Agent Knowledge Format SDK for TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 1.2.1 across all 4 locations (pyproject.toml, __init__.py, cli.py, package.json)
- Publishes the README.md and CHANGELOG.md added in PR #30 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)