### PR TITLE
Fix doctor hardcoded version and align report titles

### DIFF
--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -1391,7 +1391,8 @@ def doctor_cmd():
     click.echo()
 
     # Version
-    click.echo(f"  AKF version:    1.1.0")
+    from . import __version__
+    click.echo(f"  AKF version:    {__version__}")
     click.echo(f"  Python version: {sys.version.split()[0]}")
     click.echo(f"  Platform:       {platform.system()} {platform.machine()}")
     click.echo()

--- a/python/akf/report.py
+++ b/python/akf/report.py
@@ -440,7 +440,7 @@ def _render_json(report: EnterpriseReport) -> str:
 def _render_markdown(report: EnterpriseReport) -> str:
     """Render as executive Markdown briefing."""
     lines = [
-        "# AI Governance Report",
+        "# AKF Trust Report",
         "",
         f"*Generated: {report.generated_at}*",
         "",
@@ -846,7 +846,7 @@ def _render_pdf(report: EnterpriseReport) -> bytes:
 
     # Title
     pdf.set_font("Helvetica", "B", 18)
-    pdf.cell(0, 12, "AI Governance Report", new_x="LMARGIN", new_y="NEXT")
+    pdf.cell(0, 12, "AKF Trust Report", new_x="LMARGIN", new_y="NEXT")
     pdf.set_font("Helvetica", "", 9)
     pdf.set_text_color(120, 120, 120)
     pdf.cell(0, 6, f"Generated: {report.generated_at}", new_x="LMARGIN", new_y="NEXT")

--- a/python/tests/test_report.py
+++ b/python/tests/test_report.py
@@ -394,7 +394,7 @@ class TestMarkdownRenderer:
     def test_markdown_title(self, sample_report):
         """Markdown starts with correct title."""
         output = sample_report.render("markdown")
-        assert output.startswith("# AI Governance Report")
+        assert output.startswith("# AKF Trust Report")
 
     def test_markdown_overview_table(self, sample_report):
         """Markdown has overview table with key metrics."""
@@ -686,7 +686,7 @@ class TestCLIReport:
         """Default format is markdown."""
         result = runner.invoke(main, ["report"] + sample_akf_files)
         assert result.exit_code == 0
-        assert "# AI Governance Report" in result.output
+        assert "# AKF Trust Report" in result.output
 
     def test_cli_json_format(self, runner, sample_akf_files):
         """--format json produces valid JSON."""
@@ -858,7 +858,7 @@ class TestIntegrationPipeline:
 
         # All text formats render without error
         md = report.render("markdown")
-        assert "# AI Governance Report" in md
+        assert "# AKF Trust Report" in md
 
         html = report.render("html")
         assert "<!DOCTYPE html>" in html


### PR DESCRIPTION
## Summary
- `akf doctor` was hardcoded to show version `1.1.0` — now reads `__version__` dynamically
- Markdown and PDF report titles changed from "AI Governance Report" to "AKF Trust Report" (consistent with HTML renderer)
- Updated 3 test assertions to match

Found during E2E integration testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)