### PR TITLE
Add OpenClaw support to shell hook and marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ AKF works where AI agents work. Drop a config file, and every AI-generated file 
 | **OpenAI Codex** | Reads `AGENTS.md` — stamps files in cloud sandbox and local |
 | **Manus / Other Agents** | MCP server + shell hook — works with any agent that supports MCP or CLI |
 | **Any MCP agent** | 9 MCP tools — stamp, audit, embed, extract, detect, validate, scan, trust, create |
-| **Any CLI tool** | `eval "$(akf shell-hook)"` — intercepts `claude`, `chatgpt`, `aider`, `ollama`, `manus` |
+| **Any CLI tool** | `eval "$(akf shell-hook)"` — intercepts `claude`, `chatgpt`, `aider`, `openclaw`, `ollama`, `manus` |
 
 **The trust pipeline:**
 ```
@@ -292,7 +292,7 @@ The background watcher monitors directories for new and modified files and stamp
 eval "$(akf shell-hook)"
 ```
 
-Automatically detects when you run `claude`, `chatgpt`, `aider`, `ollama`, or other AI CLI tools, and stamps any files they create or modify. Also pre-stamps files before upload to content platforms (`gws`, `box`, `m365`, `dbxcli`, `rclone`) so trust metadata travels with the file. Use `--no-upload-hooks` to disable.
+Automatically detects when you run `claude`, `chatgpt`, `aider`, `openclaw`, `ollama`, or other AI CLI tools, and stamps any files they create or modify. Also pre-stamps files before upload to content platforms (`gws`, `box`, `m365`, `dbxcli`, `rclone`) so trust metadata travels with the file. Use `--no-upload-hooks` to disable.
 
 ### Project Rules
 

--- a/docs/getting-started-guide.md
+++ b/docs/getting-started-guide.md
@@ -51,7 +51,7 @@ stamp_file("output.pdf",
     agent="my-agent")
 ```
 
-**The outcome:** Every file your agent produces carries embedded trust metadata automatically. Claude Code, Cursor, Copilot, and any MCP agent stamp their work without manual intervention.
+**The outcome:** Every file your agent produces carries embedded trust metadata automatically. Claude Code, Cursor, OpenClaw, Copilot, and any MCP agent stamp their work without manual intervention.
 
 ---
 
@@ -199,7 +199,7 @@ The daemon monitors directories for new and modified files, using **smart contex
 eval "$(akf shell-hook)"
 ```
 
-Automatically detects when you run `claude`, `chatgpt`, `aider`, `ollama`, or other AI CLI tools, and stamps any files they create or modify. Also pre-stamps files before upload to content platforms (`gws`, `box`, `m365`, `dbxcli`, `rclone`) so trust metadata travels with the file.
+Automatically detects when you run `claude`, `chatgpt`, `aider`, `openclaw`, `ollama`, or other AI CLI tools, and stamps any files they create or modify. Also pre-stamps files before upload to content platforms (`gws`, `box`, `m365`, `dbxcli`, `rclone`) so trust metadata travels with the file.
 
 ### VS Code Extension
 

--- a/docs/launch-materials.md
+++ b/docs/launch-materials.md
@@ -30,9 +30,9 @@ provenance, or verification with that content. AKF is that format.
 - Integrations: LangChain, LlamaIndex, CrewAI, MCP
 - **Zero-touch auto-stamping** — background daemon + shell hooks + VS Code extension
 - **Smart context detection** — infers git author, download source, AI-generated flag, project classification rules
-- **Shell integration** — `eval "$(akf shell-hook)"` intercepts Claude, ChatGPT, Aider, Ollama and stamps outputs
+- **Shell integration** — `eval "$(akf shell-hook)"` intercepts Claude, ChatGPT, Aider, OpenClaw, Ollama and stamps outputs
 - **OS-native file monitoring** — kqueue on macOS, polling cross-platform
-- **Ambient Trust** — Works with Claude Code, Claude Agent Teams, Cursor, Windsurf, GitHub Copilot, OpenAI Codex, Manus, M365 Copilot — and any MCP-compatible agent
+- **Ambient Trust** — Works with Claude Code, Claude Agent Teams, Cursor, Windsurf, GitHub Copilot, OpenAI Codex, Manus, OpenClaw, M365 Copilot — and any MCP-compatible agent
 - **Trust Pipeline** — agent → git commit → CI validation → team review, all with trust metadata
 
 ---
@@ -81,7 +81,7 @@ degradation chains, etc.
 
 The latest version adds zero-touch auto-stamping. Install a background
 daemon (`akf install`) or add `eval "$(akf shell-hook)"` to your shell
-config, and every file that Claude, ChatGPT, Aider, or Ollama generates
+config, and every file that Claude, ChatGPT, Aider, OpenClaw, or Ollama generates
 gets stamped automatically. Smart context detection infers git author,
 download source, classification rules, and AI-generated flags without
 any manual intervention.
@@ -241,7 +241,7 @@ Even better — you can make it fully automatic:
     # Or install a background daemon
     akf install
 
-It intercepts claude, chatgpt, ollama, aider, and other AI tools, then
+It intercepts claude, chatgpt, openclaw, ollama, aider, and other AI tools, then
 stamps any files they create or modify. Smart context detection infers
 the model, git author, and project classification rules automatically.
 
@@ -306,7 +306,7 @@ Add one line to your shell config:
 
 eval "$(akf shell-hook)"
 
-Now every file Claude, ChatGPT, Aider, or Ollama touches gets stamped
+Now every file Claude, ChatGPT, Aider, OpenClaw, or Ollama touches gets stamped
 automatically. Smart context detection infers git author, download source,
 and project classification rules.
 
@@ -356,7 +356,7 @@ PDF, and 20+ others.
 
 For technical teams: pip install akf and you're up in 30 seconds. Add
 eval "$(akf shell-hook)" to your shell config and every file Claude,
-ChatGPT, or Copilot touches gets stamped automatically — zero manual work.
+ChatGPT, OpenClaw, or Copilot touches gets stamped automatically — zero manual work.
 
 For compliance teams: AKF maps directly to EU AI Act, SOX, and NIST AI RMF
 requirements. One command gives you an actionable compliance report.
@@ -428,7 +428,7 @@ One line in your shell config and every AI-generated file gets stamped
 automatically. Smart context detection infers git author, download source,
 and project classification rules.
 
-    eval "$(akf shell-hook)"    # Intercepts claude, chatgpt, aider, ollama
+    eval "$(akf shell-hook)"    # Intercepts claude, chatgpt, openclaw, aider, ollama
     akf install                 # Background daemon for ~/Downloads, ~/Desktop
 
 INSTALL
@@ -621,7 +621,7 @@ AKF has three layers of automatic stamping:
 eval "$(akf shell-hook)"
 ```
 
-Now whenever you run `claude`, `chatgpt`, `aider`, `ollama`, or any other AI
+Now whenever you run `claude`, `chatgpt`, `aider`, `openclaw`, `ollama`, or any other AI
 CLI tool, AKF snapshots the files before and stamps any new or modified files
 after. Smart context detection automatically infers git author, download
 source, project classification rules, and AI-generated flags.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -63,7 +63,7 @@ brief.save("weekly-brief.akf")
 # Install background daemon — watches ~/Downloads, ~/Desktop, ~/Documents
 akf install
 
-# Or add shell hook — intercepts claude, chatgpt, aider, ollama
+# Or add shell hook — intercepts claude, chatgpt, openclaw, aider, ollama
 eval "$(akf shell-hook)"    # Add to ~/.zshrc or ~/.bashrc
 ```
 

--- a/python/akf/shell_hook.py
+++ b/python/akf/shell_hook.py
@@ -8,6 +8,7 @@ Usage::
     # Now any files created/modified by AI CLI tools get auto-stamped:
     claude "Write a Python script" > script.py   # → auto-stamped
     chatgpt "Summarize this doc" > summary.md    # → auto-stamped
+    openclaw "Refactor module" > refactored.py   # → auto-stamped
     aider --message "Add tests"                  # → modified files stamped
 
 The hook works by:
@@ -38,6 +39,7 @@ AI_CLI_TOOLS = [
     "mods",
     "tgpt",
     "manus",
+    "openclaw",
 ]
 
 # Content platform CLIs that upload files — stamp *before* upload

--- a/python/tests/test_shell_hook.py
+++ b/python/tests/test_shell_hook.py
@@ -107,6 +107,7 @@ class TestAIToolsList:
         assert "chatgpt" in AI_CLI_TOOLS
         assert "aider" in AI_CLI_TOOLS
         assert "ollama" in AI_CLI_TOOLS
+        assert "openclaw" in AI_CLI_TOOLS
 
     def test_extensions_complete(self):
         assert "py" in WATCHED_EXTENSIONS

--- a/site/src/components/AutoStamping.tsx
+++ b/site/src/components/AutoStamping.tsx
@@ -3,7 +3,7 @@ import SectionHeading from '../ui/SectionHeading';
 const features = [
   {
     title: 'Shell Hook',
-    description: 'One line in your shell config. Every file Claude, ChatGPT, Aider, or Ollama touches gets stamped automatically. Also pre-stamps before upload to Google Workspace, Box, M365, Dropbox, and Rclone.',
+    description: 'One line in your shell config. Every file Claude, ChatGPT, Aider, OpenClaw, or Ollama touches gets stamped automatically. Also pre-stamps before upload to Google Workspace, Box, M365, Dropbox, and Rclone.',
     code: 'eval "$(akf shell-hook)"',
     icon: (
       <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -76,6 +76,7 @@ export default function AutoStamping() {
             Intercepts <span className="text-text-primary font-medium">Claude</span>,{' '}
             <span className="text-text-primary font-medium">ChatGPT</span>,{' '}
             <span className="text-text-primary font-medium">Aider</span>,{' '}
+            <span className="text-text-primary font-medium">OpenClaw</span>,{' '}
             <span className="text-text-primary font-medium">Ollama</span>,{' '}
             <span className="text-text-primary font-medium">Copilot</span>,{' '}
             <span className="text-text-primary font-medium">Cursor</span>, and more.

--- a/site/src/components/GetStartedPage.tsx
+++ b/site/src/components/GetStartedPage.tsx
@@ -524,7 +524,7 @@ export default function GetStartedPage() {
             <div>
               <p className="text-sm text-text-primary font-medium">Zero-touch auto-stamping</p>
               <p className="text-xs text-text-secondary mt-1">
-                <code className="text-accent">akf install</code> sets up a lightweight file watcher that auto-stamps new documents with smart context detection (git author, download source, AI-generated flags, project classification rules). Add <code className="text-accent">eval "$(akf shell-hook)"</code> to your shell config to intercept Claude, ChatGPT, Aider, and Ollama. Fully reversible with <code className="text-accent">akf uninstall</code>.
+                <code className="text-accent">akf install</code> sets up a lightweight file watcher that auto-stamps new documents with smart context detection (git author, download source, AI-generated flags, project classification rules). Add <code className="text-accent">eval "$(akf shell-hook)"</code> to your shell config to intercept Claude, ChatGPT, OpenClaw, Aider, and Ollama. Fully reversible with <code className="text-accent">akf uninstall</code>.
               </p>
             </div>
           </div>

--- a/site/src/components/WorksWith.tsx
+++ b/site/src/components/WorksWith.tsx
@@ -6,6 +6,7 @@ const agents = [
   { name: 'OpenAI Codex', category: 'Agent' },
   { name: 'Devin', category: 'Agent' },
   { name: 'Manus', category: 'Agent' },
+  { name: 'OpenClaw', category: 'Agent' },
   { name: 'GPT-4o', category: 'Model' },
   { name: 'Gemini', category: 'Model' },
   { name: 'M365 Copilot', category: 'Enterprise' },


### PR DESCRIPTION
## Summary
- Add `"openclaw"` to `AI_CLI_TOOLS` in `shell_hook.py` so the shell hook recognizes the OpenClaw CLI (247K+ GitHub stars, most popular open-source AI agent in 2026)
- Update website components (`WorksWith`, `AutoStamping`, `GetStartedPage`) to mention OpenClaw
- Update README, getting-started guide, quickstart, and launch materials (~8 copy blocks) to include OpenClaw in tool lists
- Add test assertion for `"openclaw" in AI_CLI_TOOLS`

## Test plan
- [x] `python3 -m pytest tests/test_shell_hook.py -v` — 44/44 pass
- [ ] Verify `akf shell-hook` output includes `openclaw` in the regex pattern
- [ ] Visual check of site components for OpenClaw chip/mention


🤖 Generated with [Claude Code](https://claude.com/claude-code)