### PR TITLE
Add akf-starter example and promotion content

### DIFF
--- a/docs/PROMOTION-CONTENT.md
+++ b/docs/PROMOTION-CONTENT.md
@@ -1,0 +1,154 @@
+# AKF Promotion Content — Copy-Paste Ready
+
+## Hugging Face Comments (post on trending AI Spaces)
+
+### Comment Template 1 — For text generation / chatbot Spaces
+```
+Nice Space! If you're building on top of AI outputs, you might want to check out AKF — it's an open format that embeds trust metadata (confidence scores, provenance, security labels) directly into files. Think EXIF but for AI-generated content.
+
+Live demo: https://huggingface.co/spaces/HANAKT19/akf
+GitHub: https://github.com/HMAKT99/AKF
+```
+
+### Comment Template 2 — For coding / agent Spaces
+```
+Cool project! One thing we found building AI agents — the outputs need trust metadata. AKF is an open format (MIT) that stamps every AI-generated file with trust scores, source provenance, and compliance metadata. Works with DOCX, PDF, images, and code.
+
+Try it: https://huggingface.co/spaces/HANAKT19/akf
+```
+
+### Comment Template 3 — For AI safety / responsible AI Spaces
+```
+This is great work on AI safety. We've been working on the metadata layer — AKF embeds trust scores and provenance into every file AI touches, so you can audit and verify AI outputs downstream. Already handles EU AI Act Article 50 compliance checks.
+
+Demo: https://huggingface.co/spaces/HANAKT19/akf
+Spec: https://github.com/HMAKT99/AKF
+```
+
+### Comment Template 4 — For document/RAG Spaces
+```
+Really useful! If you need to track which parts of a document were AI-generated vs human-written, AKF can help — it embeds per-claim trust metadata directly into the file (DOCX, PDF, etc.). Open format, MIT licensed.
+
+Live playground: https://huggingface.co/spaces/HANAKT19/akf
+```
+
+---
+
+## HF Collection Description
+```
+Title: AI Trust & Provenance Tools
+
+Description: Tools and demos for embedding trust metadata into AI-generated content. AKF (Agent Knowledge Format) is the AI native file format — trust scores, provenance chains, and compliance metadata that travel with your files.
+
+Tags: ai-safety, trust, provenance, metadata, compliance, eu-ai-act
+```
+
+---
+
+## Cross-Post Updates (add to existing X/Reddit/dev.to posts)
+
+### X/Twitter Reply Thread
+```
+UPDATE: Live demo now on Hugging Face — try AKF without installing anything 👇
+
+🔗 https://huggingface.co/spaces/HANAKT19/akf
+
+Stamp claims, analyze trust scores, and run security detections. All in the browser.
+```
+
+### Reddit Update Comment
+```
+**Update:** We just launched a live demo on Hugging Face Spaces — you can try AKF without installing anything:
+
+https://huggingface.co/spaces/HANAKT19/akf
+
+Three tabs:
+- **Stamp & Inspect** — Create AKF trust metadata for any claim
+- **Trust Analysis** — See how trust scores are computed
+- **Security Detections** — Find risky AI claims
+
+Would love feedback from this community.
+```
+
+### dev.to Update (add to bottom of existing article)
+```
+---
+
+## Try It Live
+
+Don't want to install anything? Try AKF in the browser on Hugging Face Spaces:
+
+👉 [AKF Live Demo](https://huggingface.co/spaces/HANAKT19/akf)
+
+You can stamp claims with trust metadata, analyze trust scores, and run security detections — all without leaving the browser.
+```
+
+---
+
+## Awesome List Submissions
+
+### awesome-nodejs (sindresorhus/awesome-nodejs)
+```
+Category: Security
+
+- [akf-format](https://github.com/HMAKT99/AKF) - Agent Knowledge Format — embed trust scores, provenance, and security classification into AI-generated files.
+```
+
+### awesome-npm (sindresorhus/awesome-npm)
+```
+Category: Packages → Security
+
+- [akf-format](https://www.npmjs.com/package/akf-format) - Trust metadata for AI-generated content. Embeds confidence scores, source provenance, and compliance metadata into DOCX, PDF, images, and code.
+```
+
+### awesome-artificial-intelligence (owainlewis/awesome-artificial-intelligence)
+```
+Category: Tools
+
+- [AKF — Agent Knowledge Format](https://github.com/HMAKT99/AKF) - The AI native file format. Embeds trust scores, provenance chains, and compliance metadata (EU AI Act, HIPAA) into every file AI touches.
+```
+
+### awesome-ai-tools
+```
+- [AKF](https://github.com/HMAKT99/AKF) - Open file format for AI trust metadata. Stamps every AI output with confidence scores, source chains, and security labels. SDKs for TypeScript and Python. [Demo](https://huggingface.co/spaces/HANAKT19/akf)
+```
+
+### awesome-generative-ai-tools
+```
+- [AKF](https://akf.dev) - The AI native file format — trust scores, provenance, and compliance that embed into DOCX, PDF, images, and code. MIT licensed. `npm install akf-format`
+```
+
+---
+
+## HF Daily Papers Comment (when AI safety papers are posted)
+```
+Relevant tool: AKF (Agent Knowledge Format) addresses exactly this — it's an open metadata format that embeds trust scores and provenance directly into files. Every AI claim carries its confidence score, source chain, and security label.
+
+The format is ~15 tokens of JSON that travels with the file. Already supports EU AI Act Article 50 compliance auditing.
+
+Demo: https://huggingface.co/spaces/HANAKT19/akf
+Paper/Spec: https://github.com/HMAKT99/AKF/tree/main/spec
+```
+
+---
+
+## GitHub Discussions / Issues Comment (on popular AI repos)
+```
+If [project name] is interested in tracking provenance of AI outputs, AKF might be useful — it's an open format (MIT) for embedding trust metadata into files.
+
+- Trust scores (0-1) per claim
+- Source provenance chains
+- Security classification
+- Compliance auditing (EU AI Act, HIPAA)
+
+npm: `npm install akf-format`
+Demo: https://huggingface.co/spaces/HANAKT19/akf
+```
+
+---
+
+## Product Hunt Tagline (for future launch)
+```
+Tagline: The AI native file format — trust metadata for every file AI touches
+Description: AKF embeds trust scores, source provenance, and compliance metadata directly into DOCX, PDF, images, and code. ~15 tokens of JSON that travel with the file. Open format, MIT licensed.
+```

--- a/examples/akf-starter/detect-demo.js
+++ b/examples/akf-starter/detect-demo.js
@@ -1,0 +1,40 @@
+/**
+ * Security detection demo — find risky AI claims.
+ *
+ * Run: npm run detect
+ */
+
+import { AKFBuilder, runAllDetections, toJSON } from "akf-format";
+
+// Build a unit with some intentional red flags
+const unit = new AKFBuilder()
+  .claim("Patient diagnosis: Type 2 diabetes confirmed", 0.6, {
+    tier: 4,
+    ai: true,
+    // No evidence, no review — detections should flag this
+  })
+  .claim("Treatment plan: Metformin 500mg twice daily", 0.55, {
+    tier: 5,
+    ai: true,
+    risk: "AI-generated medical advice without physician review",
+  })
+  .agent("medical-ai-v2")
+  .label("confidential")
+  .build();
+
+console.log("=== AKF Unit ===");
+console.log(toJSON(unit, 2));
+
+console.log("\n=== Running Security Detections ===");
+const report = runAllDetections(unit);
+
+console.log(`\nTriggered: ${report.triggeredCount}/10  Critical: ${report.criticalCount}  High: ${report.highCount}`);
+console.log(`Clean: ${report.clean}`);
+
+for (const r of report.results.filter((r) => r.triggered)) {
+  console.log(`\n  [${r.severity.toUpperCase()}] ${r.detectionClass}`);
+  for (const f of r.findings) {
+    console.log(`    - ${f}`);
+  }
+  if (r.recommendation) console.log(`    → ${r.recommendation}`);
+}

--- a/examples/akf-starter/index.js
+++ b/examples/akf-starter/index.js
@@ -1,0 +1,37 @@
+/**
+ * AKF Starter — stamp AI-generated content with trust metadata.
+ *
+ * Run: npm install && npm start
+ */
+
+import { AKFBuilder, toJSON, validate, effectiveTrust } from "akf-format";
+
+// 1. Create an AKF unit with the fluent builder
+const unit = new AKFBuilder()
+  .claim("Revenue projected at $42.1B for FY2026", 0.85, {
+    src: "financial-erp",
+    tier: 2,
+    ai: true,
+  })
+  .agent("gpt-4o")
+  .label("internal")
+  .evidence({ type: "document", detail: "10-K filing, page 47" })
+  .build();
+
+console.log("=== AKF Unit (compact JSON) ===");
+console.log(toJSON(unit, 2));
+
+// 2. Validate it
+const result = validate(unit);
+console.log("\n=== Validation ===");
+console.log(`Valid: ${result.valid}  Level: ${result.level}/3`);
+if (result.warnings.length) console.log("Warnings:", result.warnings);
+
+// 3. Compute effective trust per claim
+console.log("\n=== Trust Scores ===");
+for (const claim of unit.claims) {
+  const trust = effectiveTrust(claim);
+  console.log(`Claim: "${claim.c}"`);
+  console.log(`  Score: ${trust.score}  Decision: ${trust.decision}`);
+  console.log(`  Breakdown:`, trust.breakdown);
+}

--- a/examples/akf-starter/package-lock.json
+++ b/examples/akf-starter/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "akf-starter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "akf-starter",
+      "version": "1.0.0",
+      "dependencies": {
+        "akf-format": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/akf-format": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/akf-format/-/akf-format-1.2.2.tgz",
+      "integrity": "sha512-erjqSl6zowsZHutWnFk8HzwB6p0EnbWHota+Un4kbwuD7IunN7t4DvdoCNbTEi39Rd3CZ4YCtRHlTIoO0mFdOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/examples/akf-starter/package.json
+++ b/examples/akf-starter/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "akf-starter",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Starter template for akf-format — The AI Native File Format",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "trust": "node trust-demo.js",
+    "detect": "node detect-demo.js"
+  },
+  "dependencies": {
+    "akf-format": "^1.2.2"
+  },
+  "engines": {
+    "node": ">=16"
+  }
+}

--- a/examples/akf-starter/trust-demo.js
+++ b/examples/akf-starter/trust-demo.js
@@ -1,0 +1,32 @@
+/**
+ * Trust scoring demo — see how different inputs affect trust.
+ *
+ * Run: npm run trust
+ */
+
+import { effectiveTrust } from "akf-format";
+
+const scenarios = [
+  {
+    name: "Expert human review (tier 1)",
+    claim: { c: "Quarterly earnings beat estimates by 12%", t: 0.95, tier: 1, ai: false, src: "sec-filing", id: "a" },
+  },
+  {
+    name: "AI-generated, medium confidence (tier 3)",
+    claim: { c: "Customer churn expected to decrease 8%", t: 0.72, tier: 3, ai: true, src: "analytics-pipeline", id: "b" },
+  },
+  {
+    name: "Speculative AI claim (tier 5)",
+    claim: { c: "Market could reach $100B by 2030", t: 0.4, tier: 5, ai: true, src: "web-scrape", id: "c" },
+  },
+];
+
+for (const s of scenarios) {
+  const result = effectiveTrust(s.claim);
+
+  console.log(`\n--- ${s.name} ---`);
+  console.log(`Claim:    ${s.claim.c}`);
+  console.log(`Raw:      ${s.claim.t}  →  Effective: ${result.score}`);
+  console.log(`Decision: ${result.decision}`);
+  console.log(`Breakdown:`, result.breakdown);
+}


### PR DESCRIPTION
## Summary
- **examples/akf-starter/**: 3 runnable Node.js demos showcasing `akf-format` npm package — stamp & inspect, trust scoring comparison, and security detections
- **docs/PROMOTION-CONTENT.md**: Copy-paste ready promotion content for HF comments, X/Reddit/dev.to cross-posts, and awesome-list submissions

## Test plan
- [x] `npm start` — stamps a claim and shows trust score (ACCEPT at 0.7225)
- [x] `npm run trust` — compares 3 scenarios (tier 1→ACCEPT, tier 3→LOW, tier 5→REJECT)
- [x] `npm run detect` — finds 5/10 detections on intentionally risky medical AI claims