### PR TITLE
Fix inspect and trust commands for non-JSON files

### DIFF
--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -247,7 +247,12 @@ def validate_cmd(file) -> None:
 @click.argument("file", type=click.Path(exists=True))
 def inspect(file) -> None:
     """Pretty-print an .akf file with trust indicators."""
-    unit = load(file)
+    from . import universal as akf_u
+    meta = akf_u.extract(file)
+    if meta is not None:
+        unit = AKF(**meta)
+    else:
+        unit = load(file)
 
     click.secho(f"AKF {unit.version} | {unit.id}", bold=True)
     if unit.author:
@@ -295,7 +300,12 @@ def inspect(file) -> None:
 @click.option("--threshold", "-t", default=0.6, type=float, help="Trust threshold")
 def trust(file, threshold) -> None:
     """Compute effective trust for all claims."""
-    unit = load(file)
+    from . import universal as akf_u
+    meta = akf_u.extract(file)
+    if meta is not None:
+        unit = AKF(**meta)
+    else:
+        unit = load(file)
     results = compute_all(unit)
 
     for claim, result in zip(unit.claims, results):


### PR DESCRIPTION
## Summary
- `akf inspect` and `akf trust` crashed with `JSONDecodeError` on `.md`, `.docx`, and other non-JSON files
- Both now use `universal.extract()` to read metadata from any supported format, falling back to `load()` for `.akf` files

## Root cause
`load()` calls `json.load()` directly — only works on `.akf` JSON files. But `akf stamp` embeds metadata in YAML frontmatter for `.md` files, custom XML for `.docx`, etc.

## Test plan
- [x] `akf stamp test.md && akf inspect test.md` — no longer crashes
- [x] `akf stamp test.md && akf trust test.md` — no longer crashes
- [x] 1,896 existing tests pass