### PR TITLE
Fix embed command wiping metadata when called with no arguments

### DIFF
--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -433,6 +433,16 @@ def embed_cmd(file, classification, claim, trust, src, ai, agent) -> None:
             "at": datetime.now(timezone.utc).isoformat(),
         })
 
+    # If no new claims or metadata provided, re-embed existing metadata
+    if not claims and not metadata:
+        existing = akf_u.extract(file)
+        if existing:
+            akf_u.embed(file, metadata=existing)
+            click.secho("Re-embedded existing AKF metadata into {}".format(file), fg="green")
+        else:
+            click.secho("No AKF metadata found to embed. Use --claim to add claims.", fg="yellow")
+        return
+
     akf_u.embed(file, claims=claims if claims else None, metadata=metadata if metadata else None,
                 classification=classification)
     click.secho("Embedded AKF metadata into {}".format(file), fg="green")


### PR DESCRIPTION
## Summary
- `akf embed file.md` with no flags overwrote existing AKF metadata with `{}`
- Now detects when no new data is provided and re-embeds existing metadata
- Shows helpful message if file has no metadata to embed

## Root cause
`embed_cmd` passed `claims=None, metadata=None` to `universal.embed()`, which wrote an empty dict over the frontmatter.

## Test plan
- [x] `akf stamp test.md && akf embed test.md && akf read test.md` — metadata preserved
- [x] 1,896 existing tests pass