### PR TITLE
Serve JSON schema at /schema/v1.1.json

### DIFF
--- a/site/public/schema/v1.1.json
+++ b/site/public/schema/v1.1.json
@@ -1,0 +1,655 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://akf.dev/schema/v1.1",
+  "title": "AKF — Agent Knowledge Format v1.1",
+  "description": "Lightweight, LLM-native file format for structured knowledge exchange with built-in trust, provenance, and security metadata.",
+  "type": "object",
+  "required": ["v", "claims"],
+  "additionalProperties": true,
+  "properties": {
+    "v": {
+      "type": "string",
+      "description": "Spec version (semver)",
+      "pattern": "^\\d+\\.\\d+(\\.\\d+)?$"
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique knowledge unit ID"
+    },
+    "by": {
+      "type": "string",
+      "description": "Creator (email or agent ID)"
+    },
+    "agent": {
+      "type": "string",
+      "description": "AI agent ID if AI-created"
+    },
+    "model": {
+      "type": "string",
+      "description": "Model identifier (e.g. claude-opus-4-6)"
+    },
+    "tools": {
+      "type": "array",
+      "description": "Tools used by the agent",
+      "items": { "type": "string" }
+    },
+    "session": {
+      "type": "string",
+      "description": "Session identifier for grouping units"
+    },
+    "at": {
+      "type": "string",
+      "description": "Creation timestamp (ISO-8601)",
+      "format": "date-time"
+    },
+    "label": {
+      "type": "string",
+      "description": "Security classification",
+      "enum": ["public", "internal", "confidential", "highly-confidential", "restricted"]
+    },
+    "inherit": {
+      "type": "boolean",
+      "description": "Children must inherit this label",
+      "default": true
+    },
+    "ext": {
+      "type": "boolean",
+      "description": "Allow external sharing",
+      "default": false
+    },
+    "ttl": {
+      "type": "integer",
+      "description": "Retention period in days",
+      "minimum": 0
+    },
+    "claims": {
+      "type": "array",
+      "description": "Array of claim objects",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/Claim"
+      }
+    },
+    "prov": {
+      "type": "array",
+      "description": "Provenance chain (array of hops)",
+      "items": {
+        "$ref": "#/$defs/ProvHop"
+      }
+    },
+    "hash": {
+      "type": "string",
+      "description": "Integrity hash of file contents",
+      "pattern": "^(sha256|sha3-512|blake3):.*$"
+    },
+    "meta": {
+      "type": "object",
+      "description": "Free-form extension metadata",
+      "additionalProperties": true
+    },
+    "made_by": {
+      "type": "array",
+      "description": "Full authorship chain",
+      "items": { "$ref": "#/$defs/MadeBy" }
+    },
+    "reviews": {
+      "type": "array",
+      "description": "Unit-level reviews",
+      "items": { "$ref": "#/$defs/Review" }
+    },
+    "security": {
+      "type": "object",
+      "description": "Security block (access_control, trust_anchors, redaction_policy)",
+      "additionalProperties": true
+    },
+    "compliance": {
+      "type": "object",
+      "description": "Compliance block (regulations, last_audit, auto_audit)",
+      "additionalProperties": true
+    },
+    "cost": {
+      "$ref": "#/$defs/CostMetadata"
+    },
+    "annotations": {
+      "type": "array",
+      "description": "Unit-level annotations",
+      "items": { "$ref": "#/$defs/Annotation" }
+    },
+    "sv": {
+      "type": "string",
+      "description": "Schema version for forward compatibility",
+      "default": "1.1"
+    },
+    "parent": {
+      "type": "string",
+      "description": "Parent unit ID for derivation lineage"
+    },
+    "sig": {
+      "type": "string",
+      "description": "Base64-encoded Ed25519 signature"
+    },
+    "sig_algo": {
+      "type": "string",
+      "description": "Signature algorithm (e.g. ed25519)",
+      "enum": ["ed25519"]
+    },
+    "key_id": {
+      "type": "string",
+      "description": "SHA-256 fingerprint of the signer's public key"
+    },
+    "sig_at": {
+      "type": "string",
+      "description": "Signing timestamp (ISO-8601)",
+      "format": "date-time"
+    },
+    "sig_by": {
+      "type": "string",
+      "description": "Signer identifier (email or agent ID)"
+    }
+  },
+  "$defs": {
+    "Claim": {
+      "type": "object",
+      "required": ["c", "t"],
+      "additionalProperties": true,
+      "properties": {
+        "c": {
+          "type": "string",
+          "description": "The knowledge claim content"
+        },
+        "t": {
+          "type": "number",
+          "description": "Trust/confidence score",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "id": {
+          "type": "string",
+          "description": "Claim ID"
+        },
+        "src": {
+          "type": "string",
+          "description": "Source name"
+        },
+        "uri": {
+          "type": "string",
+          "description": "Source URL",
+          "format": "uri"
+        },
+        "tier": {
+          "type": "integer",
+          "description": "Authority tier",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "ver": {
+          "type": "boolean",
+          "description": "Human verified"
+        },
+        "ver_by": {
+          "type": "string",
+          "description": "Who verified"
+        },
+        "ai": {
+          "type": "boolean",
+          "description": "AI generated flag"
+        },
+        "risk": {
+          "type": "string",
+          "description": "Risk description"
+        },
+        "decay": {
+          "type": "integer",
+          "description": "Half-life in days",
+          "minimum": 0
+        },
+        "exp": {
+          "type": "string",
+          "description": "Hard expiry date (ISO-8601)",
+          "format": "date-time"
+        },
+        "tags": {
+          "type": "array",
+          "description": "Free-form tags",
+          "items": { "type": "string" }
+        },
+        "contra": {
+          "type": "string",
+          "description": "ID of contradicting claim"
+        },
+        "fidelity": {
+          "$ref": "#/$defs/Fidelity"
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind of claim: claim, code_change, decision, suggestion, review, test_result, diagnosis"
+        },
+        "evidence": {
+          "type": "array",
+          "description": "Evidence supporting the claim",
+          "items": { "$ref": "#/$defs/Evidence" }
+        },
+        "origin": {
+          "$ref": "#/$defs/Origin"
+        },
+        "reviews": {
+          "type": "array",
+          "description": "Claim-level reviews",
+          "items": { "$ref": "#/$defs/Review" }
+        },
+        "source_detail": {
+          "$ref": "#/$defs/SourceDetail"
+        },
+        "reasoning": {
+          "$ref": "#/$defs/ReasoningChain"
+        },
+        "freshness": {
+          "$ref": "#/$defs/Freshness"
+        },
+        "annotations": {
+          "type": "array",
+          "description": "Claim-level annotations",
+          "items": { "$ref": "#/$defs/Annotation" }
+        },
+        "cost": {
+          "$ref": "#/$defs/CostMetadata"
+        },
+        "sup": {
+          "type": "string",
+          "description": "ID of claim this supersedes"
+        },
+        "cal": {
+          "$ref": "#/$defs/Calibration"
+        }
+      }
+    },
+    "Evidence": {
+      "type": "object",
+      "required": ["type", "detail"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Evidence type: test_pass, type_check, lint_clean, ci_pass, human_review, other"
+        },
+        "detail": {
+          "type": "string",
+          "description": "Description of the evidence"
+        },
+        "at": {
+          "type": "string",
+          "description": "Timestamp (ISO-8601)",
+          "format": "date-time"
+        },
+        "tool": {
+          "type": "string",
+          "description": "Tool that produced this evidence"
+        }
+      }
+    },
+    "Fidelity": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "h": {
+          "type": "string",
+          "description": "Headline (~5 tokens)"
+        },
+        "s": {
+          "type": "string",
+          "description": "Summary (~50 tokens)"
+        },
+        "f": {
+          "type": "string",
+          "description": "Full detail (~2000 tokens)"
+        }
+      }
+    },
+    "ProvHop": {
+      "type": "object",
+      "required": ["hop", "by", "do", "at"],
+      "additionalProperties": true,
+      "properties": {
+        "hop": {
+          "type": "integer",
+          "description": "Hop number (0 = origin)",
+          "minimum": 0
+        },
+        "by": {
+          "type": "string",
+          "description": "Actor (email or agent ID)"
+        },
+        "do": {
+          "type": "string",
+          "description": "Action performed",
+          "enum": ["created", "enriched", "reviewed", "consumed", "transformed"]
+        },
+        "at": {
+          "type": "string",
+          "description": "Timestamp (ISO-8601)",
+          "format": "date-time"
+        },
+        "h": {
+          "type": "string",
+          "description": "SHA-256 hash of this hop"
+        },
+        "pen": {
+          "type": "number",
+          "description": "Transform penalty applied",
+          "exclusiveMaximum": 0
+        },
+        "adds": {
+          "type": "array",
+          "description": "Claim IDs added in this hop",
+          "items": { "type": "string" }
+        },
+        "drops": {
+          "type": "array",
+          "description": "Claim IDs rejected in this hop",
+          "items": { "type": "string" }
+        },
+        "in_h": {
+          "type": "string",
+          "description": "Hash of input state"
+        },
+        "out_h": {
+          "type": "string",
+          "description": "Hash of output state"
+        },
+        "agent_profile": {
+          "$ref": "#/$defs/AgentProfile"
+        },
+        "dur": {
+          "type": "integer",
+          "description": "Processing duration in milliseconds",
+          "minimum": 0
+        },
+        "tools": {
+          "type": "array",
+          "description": "Tools invoked during this hop",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "Origin": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Origin type",
+          "enum": ["human", "ai", "human_assisted_by_ai", "ai_supervised_by_human", "ai_chain"]
+        },
+        "model": {
+          "type": "string",
+          "description": "Model identifier"
+        },
+        "ver": {
+          "type": "string",
+          "description": "Model version"
+        },
+        "prov": {
+          "type": "string",
+          "description": "Provider name"
+        },
+        "params": {
+          "$ref": "#/$defs/GenerationParams"
+        }
+      }
+    },
+    "GenerationParams": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "temp": {
+          "type": "number",
+          "description": "Temperature",
+          "minimum": 0
+        },
+        "top_p": {
+          "type": "number",
+          "description": "Top-p sampling",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "max_tok": {
+          "type": "integer",
+          "description": "Maximum tokens"
+        },
+        "sys_hash": {
+          "type": "string",
+          "description": "Hash of the system prompt"
+        },
+        "tools": {
+          "type": "array",
+          "description": "Tool names available during generation",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "MadeBy": {
+      "type": "object",
+      "required": ["by"],
+      "additionalProperties": true,
+      "properties": {
+        "by": {
+          "type": "string",
+          "description": "Actor identifier"
+        },
+        "role": {
+          "type": "string",
+          "description": "Role in authorship",
+          "enum": ["author", "reviewer", "editor", "approver", "system"]
+        },
+        "at": {
+          "type": "string",
+          "description": "Timestamp (ISO-8601)",
+          "format": "date-time"
+        }
+      }
+    },
+    "Review": {
+      "type": "object",
+      "required": ["by", "v"],
+      "additionalProperties": true,
+      "properties": {
+        "by": {
+          "type": "string",
+          "description": "Reviewer identifier"
+        },
+        "v": {
+          "type": "string",
+          "description": "Review verdict",
+          "enum": ["approved", "rejected", "needs_changes"]
+        },
+        "msg": {
+          "type": "string",
+          "description": "Review comment"
+        },
+        "at": {
+          "type": "string",
+          "description": "Review timestamp (ISO-8601)",
+          "format": "date-time"
+        }
+      }
+    },
+    "SourceDetail": {
+      "type": "object",
+      "required": ["uri"],
+      "additionalProperties": true,
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "Source URI",
+          "format": "uri"
+        },
+        "at": {
+          "type": "string",
+          "description": "Retrieval timestamp (ISO-8601)",
+          "format": "date-time"
+        },
+        "h": {
+          "type": "string",
+          "description": "Hash of the source content"
+        },
+        "pg": {
+          "type": "integer",
+          "description": "Page number"
+        },
+        "sec": {
+          "type": "string",
+          "description": "Section reference"
+        }
+      }
+    },
+    "ReasoningChain": {
+      "type": "object",
+      "required": ["steps"],
+      "additionalProperties": true,
+      "properties": {
+        "steps": {
+          "type": "array",
+          "description": "Reasoning steps",
+          "items": { "type": "string" }
+        },
+        "end": {
+          "type": "string",
+          "description": "Final conclusion"
+        },
+        "model": {
+          "type": "string",
+          "description": "Model used for reasoning"
+        },
+        "tok": {
+          "type": "integer",
+          "description": "Token count for reasoning"
+        }
+      }
+    },
+    "Annotation": {
+      "type": "object",
+      "required": ["k", "val"],
+      "additionalProperties": true,
+      "properties": {
+        "k": {
+          "type": "string",
+          "description": "Annotation key"
+        },
+        "val": {
+          "description": "Annotation value (any type)"
+        },
+        "scope": {
+          "type": "string",
+          "description": "Scope of the annotation",
+          "enum": ["claim", "unit", "provenance"]
+        },
+        "at": {
+          "type": "string",
+          "description": "Timestamp (ISO-8601)",
+          "format": "date-time"
+        }
+      }
+    },
+    "Freshness": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "at": {
+          "type": "string",
+          "description": "Retrieval timestamp (ISO-8601)",
+          "format": "date-time"
+        },
+        "until": {
+          "type": "string",
+          "description": "Valid until timestamp (ISO-8601)",
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "description": "URL to refresh this data",
+          "format": "uri"
+        },
+        "stale_h": {
+          "type": "integer",
+          "description": "Hours after which data is considered stale",
+          "minimum": 0
+        }
+      }
+    },
+    "CostMetadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "in_tok": {
+          "type": "integer",
+          "description": "Input token count"
+        },
+        "out_tok": {
+          "type": "integer",
+          "description": "Output token count"
+        },
+        "model": {
+          "type": "string",
+          "description": "Model used"
+        },
+        "cost": {
+          "type": "number",
+          "description": "Cost in USD",
+          "minimum": 0
+        }
+      }
+    },
+    "Calibration": {
+      "type": "object",
+      "required": ["method"],
+      "additionalProperties": true,
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "Calibration method",
+          "enum": ["self_reported", "source_verified", "externally_audited"]
+        },
+        "verifier": {
+          "type": "string",
+          "description": "Entity that performed verification"
+        },
+        "ver_at": {
+          "type": "string",
+          "description": "Verification timestamp (ISO-8601)",
+          "format": "date-time"
+        }
+      }
+    },
+    "AgentProfile": {
+      "type": "object",
+      "required": ["id"],
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Agent identifier"
+        },
+        "name": {
+          "type": "string",
+          "description": "Agent display name"
+        },
+        "ver": {
+          "type": "string",
+          "description": "Agent version"
+        },
+        "caps": {
+          "type": "array",
+          "description": "Agent capabilities",
+          "items": { "type": "string" }
+        },
+        "ceil": {
+          "type": "number",
+          "description": "Maximum trust ceiling for this agent",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `akf.dev/schema/v1.1.json` was returning 404
- Schema file now served as a static asset from `site/public/schema/`
- Referenced in HN posts, README, and docs as the canonical schema URL

## Test plan
- [x] `npm run build` includes `dist/schema/v1.1.json`
- [x] Vercel headers in `vercel.json` already set `Content-Type: application/json` and CORS for `/schema/*`