### PR TITLE
Add security headers and restrict API to GET only

### DIFF
--- a/site/api/moltbook-stats.ts
+++ b/site/api/moltbook-stats.ts
@@ -4,6 +4,10 @@ const MOLTBOOK_API = 'https://www.moltbook.com/api/v1';
 const AGENT_NAME = 'akf-agent';
 
 export default async function handler(_req: VercelRequest, res: VercelResponse) {
+  if (_req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
   res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=120');
   res.setHeader('Access-Control-Allow-Origin', '*');
 

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -7,6 +7,16 @@
   ],
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://www.moltbook.com https://api.github.com; frame-ancestors 'none'" }
+      ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
## Summary
- Add security headers to all responses: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`, `Content-Security-Policy`
- Return 405 for non-GET requests to `/api/moltbook-stats`

## Test plan
- [ ] `curl -sI https://akf.dev/` shows all security headers
- [ ] `curl -X POST /api/moltbook-stats` returns 405
- [ ] Site still loads correctly (CSP allows required domains)