### PR TITLE
Fix XSS in HTML embed and add input validation

### DIFF
--- a/python/akf/formats/html.py
+++ b/python/akf/formats/html.py
@@ -45,6 +45,8 @@ class HTMLHandler(AKFFormatHandler):
             content = f.read()
 
         akf_json = json.dumps(metadata, separators=(",", ":"), ensure_ascii=False)
+        # Escape </script> sequences to prevent XSS — standard practice for inline JSON
+        akf_json = akf_json.replace("</", "<\\/")
         script_tag = '<script type="application/akf+json">{}</script>'.format(akf_json)
 
         # If an AKF script tag already exists, replace it

--- a/python/akf/universal.py
+++ b/python/akf/universal.py
@@ -164,6 +164,32 @@ class _SidecarFallbackHandler(AKFFormatHandler):
 
 _SIDECAR_HANDLER = _SidecarFallbackHandler()
 
+MAX_CLAIM_SIZE = 100_000  # 100KB per claim field
+MAX_CLAIMS = 1_000
+
+
+def _sanitize_string(value: str) -> str:
+    """Strip path traversal sequences from string values."""
+    return value.replace("../", "").replace("..\\", "")
+
+
+def _validate_metadata(meta: Dict[str, Any]) -> None:
+    """Validate metadata before embedding — size limits and sanitization."""
+    claims = meta.get("claims", [])
+    if len(claims) > MAX_CLAIMS:
+        raise ValueError(f"Too many claims ({len(claims)}). Maximum is {MAX_CLAIMS}.")
+
+    for claim in claims:
+        for key in ("c", "content", "src", "source"):
+            val = claim.get(key)
+            if isinstance(val, str):
+                if len(val) > MAX_CLAIM_SIZE:
+                    raise ValueError(
+                        f"Claim field '{key}' exceeds {MAX_CLAIM_SIZE:,} byte limit "
+                        f"({len(val):,} bytes)."
+                    )
+                claim[key] = _sanitize_string(val)
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -206,6 +232,9 @@ def embed(
     # Merge any extra kwargs
     for key, value in kwargs.items():
         meta[key] = value
+
+    # Input validation
+    _validate_metadata(meta)
 
     handler = _resolve_handler(filepath)
     if handler is not None:


### PR DESCRIPTION
## Summary
- **XSS fix:** Escape `</script>` sequences in HTML JSON-LD embed to prevent script injection
- **Size limit:** Reject claim fields exceeding 100KB (prevents DoS via payload bloat)
- **Path traversal:** Strip `../` sequences from claim string fields (`src`, `content`)
- **Claim limit:** Max 1,000 claims per document

## Test plan
- [x] `<script>alert(1)</script>` in claim → stored as `<\/script>` in HTML
- [x] 200KB claim → raises `ValueError`
- [x] `../../../etc/passwd` in source → stored as `etc/passwd`
- [x] 1,896 existing tests pass