### PR TITLE
Compute integrity hash on stamp

### DIFF
--- a/python/akf/stamp.py
+++ b/python/akf/stamp.py
@@ -220,6 +220,12 @@ def stamp_file(
         allow_external=False,
     )
 
+    # Compute integrity hash of the file content before embedding
+    import hashlib
+    with open(filepath, "rb") as fh:
+        file_hash = hashlib.sha256(fh.read()).hexdigest()[:16]
+    unit = unit.model_copy(update={"integrity_hash": f"sha256:{file_hash}"})
+
     # Embed into the file using universal format layer
     from .universal import embed as _embed
     _embed(filepath, metadata=unit.to_dict(compact=True))


### PR DESCRIPTION
## Summary
- `stamp_file` now computes SHA-256 hash of file content before embedding
- Stored as `integrity_hash` field (e.g. `sha256:8fb4b00cf9252b1e`)
- Enables tamper detection: if content changes after stamping, hash won't match

## Test plan
- [x] `akf stamp file.md` → metadata includes `hash: sha256:...`
- [x] 1,896 existing tests pass