### PR TITLE
Add CommonJS support to npm package

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akf-format",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "AKF — Agent Knowledge Format SDK for TypeScript",
   "type": "module",
   "main": "./dist/index.js",
@@ -8,11 +8,12 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
+      "require": "./dist/cjs/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
     "test": "vitest run"
   },
   "devDependencies": {
@@ -33,7 +34,7 @@
     "url": "https://github.com/HMAKT99/AKF/issues"
   },
   "files": [
-    "dist",
+    "dist/**",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"

--- a/typescript/tsconfig.cjs.json
+++ b/typescript/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "dist/cjs",
+    "declaration": false
+  }
+}


### PR DESCRIPTION
## Summary
- `require('akf-format')` was broken — `ERR_PACKAGE_PATH_NOT_EXPORTED`
- Package only had ESM exports, no CJS entry point
- Now ships dual ESM (`dist/index.js`) + CJS (`dist/cjs/index.js`) builds
- Bumped to 1.2.7

## Test plan
- [x] `require('akf-format')` works — 43 functions exported
- [x] `import * as akf from 'akf-format'` still works
- [x] 188 TypeScript tests pass