### PR TITLE
Add MCP Registry manifest and bump to 1.2.9

### DIFF
--- a/huggingface/README.md
+++ b/huggingface/README.md
@@ -1,5 +1,5 @@
 ---
-title: AKF — Agent Knowledge Format
+title: AKF — The AI Native File Format
 emoji: 🛡️
 colorFrom: blue
 colorTo: indigo
@@ -8,5 +8,16 @@ sdk_version: "5.23.0"
 app_file: app.py
 pinned: false
 license: mit
-short_description: "EXIF for AI — stamp, trust-score, and detect AI claims"
+short_description: "EXIF for AI — trust scores, provenance, and compliance for AI-generated content"
+tags:
+  - trust
+  - metadata
+  - compliance
+  - eu-ai-act
+  - provenance
+  - ai-safety
+  - ai-governance
+  - file-format
+  - llm
+  - agent
 ---

--- a/packages/mcp-server-akf/server.json
+++ b/packages/mcp-server-akf/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.HMAKT99/akf",
+  "description": "The AI native file format. EXIF for AI — trust, provenance, and compliance for 20+ formats.",
+  "repository": {
+    "url": "https://github.com/HMAKT99/AKF",
+    "source": "github",
+    "subfolder": "packages/mcp-server-akf"
+  },
+  "version": "1.2.9",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "akf-format",
+      "version": "1.2.9",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "akf-format",
-  "version": "1.2.8",
+  "version": "1.2.9",
+  "mcpName": "io.github.HMAKT99/akf",
   "description": "AKF — Agent Knowledge Format SDK for TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Published to official MCP Registry and npm. Updated HF Space tags.