### PR TITLE
Allow npm API in CSP for download stats

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -13,7 +13,7 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://www.moltbook.com https://api.github.com https://va.vercel-scripts.com https://vitals.vercel-insights.com; frame-ancestors 'none'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://www.moltbook.com https://api.github.com https://api.npmjs.org https://va.vercel-scripts.com https://vitals.vercel-insights.com; frame-ancestors 'none'" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Add `https://api.npmjs.org` to CSP `connect-src` so the stats widget can fetch npm download counts
- Without this, the browser blocks the fetch and downloads show as 0

Follows #98.