### PR TITLE
fix: validate evidence type in stampFile and confidence type in create (#100 #101)

### DIFF
--- a/typescript/src/core.ts
+++ b/typescript/src/core.ts
@@ -65,6 +65,11 @@ export function create(
   t: number,
   opts?: Partial<Omit<Claim, "c" | "t">>
 ): AKFUnit {
+  if (typeof t !== "number" || !Number.isFinite(t) || t < 0 || t > 1) {
+    throw new TypeError(
+      `create: 'confidence' must be a finite number in [0, 1] (got ${typeof t}: ${JSON.stringify(t)})`
+    );
+  }
   const claim: Claim = {
     c: content,
     t,

--- a/typescript/src/file.ts
+++ b/typescript/src/file.ts
@@ -542,7 +542,12 @@ export function stampFile(filepath: string, options: StampOptions = {}): AKFUnit
   }
 
   // Add evidence to claims if provided
-  if (evidence && evidence.length > 0) {
+  if (evidence != null) {
+    if (!Array.isArray(evidence)) {
+      throw new TypeError(
+        `stampFile: 'evidence' must be an array of strings or evidence objects (got ${typeof evidence})`
+      );
+    }
     const evidenceObjs = evidence.map((e) => ({
       type: detectEvidenceType(e),
       detail: e,


### PR DESCRIPTION
## Summary

Two runtime input validation fixes for the AKF SDK:

### #101 — `stampFile()` crashes when `evidence` is a string

`stampFile()` assumes `evidence` is an array, but passing a string (which matches the CLI's `--evidence "..."` usage) crashes with `TypeError: evidence.map is not a function`.

**Fix**: Validate that `evidence` is an array. If not, throw a clear `TypeError`:
```
stampFile: 'evidence' must be an array of strings or evidence objects (got string)
```

### #100 — `create()` silently accepts object as confidence

`create(content, t, opts)` stores whatever is passed as `t` directly in `claims[0].t`. When a user passes an options object (common in "always-options" SDKs), the trust score silently becomes an object, causing `effectiveTrust()` to return `{ score: null, decision: 'REJECT' }`.

**Fix**: Validate that `t` is a finite number in `[0, 1]`. If not, throw a clear `TypeError`:
```
create: 'confidence' must be a finite number in [0, 1] (got object: {...})
```

## Testing

All 188 existing tests pass with these changes. The fixes are backward-compatible — valid inputs behave identically.

Fixes #100 #101
