### PR TITLE
Validate inputs in akf-format create() and stampFile()

### DIFF
--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `akf-format` will be documented in this file.
 
 This project follows [semantic versioning](https://semver.org/).
 
+## [1.2.10] — 2026-05-24
+
+### Fixed
+- `create()` now throws a clear `TypeError` when the second argument is not a finite number in `[0, 1]` (was silently producing units that broke `effectiveTrust`) — #100
+- `stampFile()` now accepts a single evidence string and auto-wraps it into an array; non-string non-array values throw a clear validation error (was throwing a cryptic `evidence.map is not a function`) — #101
+- `createMulti()` validates each claim's `t` value with the same rules as `create()`
+
 ## [1.2.1] — 2026-03-19
 
 ### Fixed

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akf-format",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "mcpName": "io.github.HMAKT99/akf",
   "description": "AKF — Agent Knowledge Format SDK for TypeScript",
   "type": "module",

--- a/typescript/src/core.ts
+++ b/typescript/src/core.ts
@@ -59,12 +59,27 @@ export function stripNulls<T>(obj: T): T {
 // Create
 // ---------------------------------------------------------------------------
 
+function assertConfidence(t: unknown, label: string): asserts t is number {
+  if (typeof t !== "number" || !Number.isFinite(t) || t < 0 || t > 1) {
+    const hint =
+      t !== null && typeof t === "object"
+        ? " — did you mean create(content, confidence, options)?"
+        : "";
+    throw new TypeError(
+      `${label} must be a finite number in [0, 1], got ${
+        t === null ? "null" : typeof t
+      }${hint}`
+    );
+  }
+}
+
 /** Create a single-claim AKF unit. */
 export function create(
   content: string,
   t: number,
   opts?: Partial<Omit<Claim, "c" | "t">>
 ): AKFUnit {
+  assertConfidence(t, "create: 'confidence' (2nd arg)");
   const claim: Claim = {
     c: content,
     t,
@@ -84,12 +99,16 @@ export function createMulti(
   claims: Partial<Claim>[],
   envelope?: Partial<Omit<AKFUnit, "v" | "claims">>
 ): AKFUnit {
-  const claimObjects: Claim[] = claims.map((c) => ({
-    ...c,
-    c: c.c || "",
-    t: c.t ?? 0.7,
-    id: c.id || shortId(),
-  }));
+  const claimObjects: Claim[] = claims.map((c, i) => {
+    const t = c.t ?? 0.7;
+    assertConfidence(t, `createMulti: claims[${i}].t`);
+    return {
+      ...c,
+      c: c.c || "",
+      t,
+      id: c.id || shortId(),
+    };
+  });
   return {
     v: AKF_VERSION,
     claims: claimObjects,

--- a/typescript/src/file.ts
+++ b/typescript/src/file.ts
@@ -501,7 +501,8 @@ export interface StampOptions {
   claims?: Array<string | Partial<Claim>>;
   trustScore?: number;
   classification?: string;
-  evidence?: string[];
+  /** Evidence strings. A single string is accepted and wrapped automatically. */
+  evidence?: string | string[];
 }
 
 /**
@@ -515,8 +516,23 @@ export function stampFile(filepath: string, options: StampOptions = {}): AKFUnit
     claims: rawClaims = [],
     trustScore = 0.7,
     classification,
-    evidence,
+    evidence: rawEvidence,
   } = options;
+
+  let evidence: string[] | undefined;
+  if (rawEvidence !== undefined) {
+    if (typeof rawEvidence === "string") {
+      evidence = [rawEvidence];
+    } else if (Array.isArray(rawEvidence)) {
+      evidence = rawEvidence;
+    } else {
+      throw new TypeError(
+        `stampFile: 'evidence' must be a string or string[], got ${
+          rawEvidence === null ? "null" : typeof rawEvidence
+        }`
+      );
+    }
+  }
 
   const claims: Partial<Claim>[] = rawClaims.map((c) => {
     const base = typeof c === "string"

--- a/typescript/tests/core.test.ts
+++ b/typescript/tests/core.test.ts
@@ -36,6 +36,20 @@ describe("create", () => {
     expect(unit.claims[0].id).toBeDefined();
     expect(typeof unit.claims[0].id).toBe("string");
   });
+
+  it("should reject an options object passed as confidence (issue #100)", () => {
+    expect(() =>
+      // @ts-expect-error — runtime check for users without TS types
+      create("text", { confidence: 0.9, source: "src" })
+    ).toThrowError(/did you mean create\(content, confidence, options\)/);
+  });
+
+  it("should reject confidence outside [0, 1]", () => {
+    expect(() => create("text", 1.5)).toThrowError(/finite number in \[0, 1\]/);
+    expect(() => create("text", -0.1)).toThrowError(/finite number in \[0, 1\]/);
+    // @ts-expect-error — runtime check
+    expect(() => create("text", NaN)).toThrowError(/finite number/);
+  });
 });
 
 describe("createMulti", () => {

--- a/typescript/tests/file.test.ts
+++ b/typescript/tests/file.test.ts
@@ -105,6 +105,25 @@ describe("stampFile", () => {
     const sidecarContent = JSON.parse(readFileSync(sidecar, "utf-8"));
     expect(sidecarContent.claims.length).toBe(1);
   });
+
+  it("should accept a single evidence string (issue #101)", () => {
+    const filepath = join(tmpDir, "ev.md");
+    writeFileSync(filepath, "# Hello\n", "utf-8");
+    const unit = stampFile(filepath, { agent: "test", evidence: "tests pass" });
+    const ev = unit.claims[0].evidence;
+    expect(Array.isArray(ev)).toBe(true);
+    expect(ev!.length).toBe(1);
+    expect(ev![0].detail).toBe("tests pass");
+  });
+
+  it("should reject non-string non-array evidence with a clear error", () => {
+    const filepath = join(tmpDir, "ev.md");
+    writeFileSync(filepath, "# Hello\n", "utf-8");
+    expect(() =>
+      // @ts-expect-error — runtime check for JS callers
+      stampFile(filepath, { evidence: 42 })
+    ).toThrowError(/'evidence' must be a string or string\[\]/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #100 and #101 — two npm-shipped bugs that silently produced garbage instead of failing fast.

## Changes

**`create()`** — throws `TypeError` when confidence isn't a finite number in `[0, 1]`. Previously a call like `create('text', { confidence: 0.9, source: 'src' })` would silently store the options object as `claims[0].t` and then `effectiveTrust()` would return `{ score: null, decision: 'REJECT' }` downstream. The error message hints at the correct shape when an object is passed.

**`createMulti()`** — same validation applied to each claim's `t`.

**`stampFile()`** — accepts a single evidence string (auto-wrapped into a one-element array, matching CLI ergonomics where `--evidence "tests pass"` is a string). Non-string, non-array values throw a clear `TypeError` instead of the previous `evidence.map is not a function`. `StampOptions.evidence` widened to `string | string[]`.

## Tests

- `tests/core.test.ts` — 3 new cases (object-as-confidence, out-of-range, NaN)
- `tests/file.test.ts` — 2 new cases (string auto-wrap, bad type rejection)
- Full suite: 192/192 passing

## Verification

```
$ node -e "import('akf-format').then(a => a.create('x', {c:0.9}))"
TypeError: create: 'confidence' (2nd arg) must be a finite number in [0, 1],
got object — did you mean create(content, confidence, options)?

$ node -e "import('akf-format').then(a => a.stampFile('f.md',{evidence:'x'}))"
# now succeeds, evidence becomes [{ type: 'other', detail: 'x', at: ... }]
```

Version bumped to `1.2.10`, CHANGELOG updated.