### PR TITLE
Handle string-shaped 'by' field in certify._extract_agent_id

### DIFF
--- a/python/akf/certify.py
+++ b/python/akf/certify.py
@@ -323,9 +323,11 @@ def _extract_agent_id(filepath: str) -> Optional[str]:
     if agent:
         return agent
 
-    # Try made_by
+    # Try made_by (can be a string or a dict)
     made_by = meta.get("made_by", meta.get("by"))
-    if made_by:
+    if isinstance(made_by, str):
+        return made_by
+    if isinstance(made_by, dict):
         return made_by.get("agent", made_by.get("a"))
 
     return None


### PR DESCRIPTION
## What
`certify._extract_agent_id()` assumed `meta['by']` was a dict and called `.get('agent')` on it. When `by` is set as a plain string (the common shape produced by `delegate()` and `stamp()`), this raised `AttributeError: 'str' object has no attribute 'get'` and broke `certify_team()` for any team produced through the delegation pipeline.

## Fix
Guard the string case explicitly; only call `.get()` on dicts.

```python
made_by = meta.get("made_by", meta.get("by"))
if isinstance(made_by, str):
    return made_by
if isinstance(made_by, dict):
    return made_by.get("agent", made_by.get("a"))
```

## Why this matters now
The existing test `test_agent_card_to_delegation_to_certify` has been failing on `main` since 2026-04-06, which means **CI has been red on main for ~7 weeks**. The `publish.yml` workflow gates `publish-npm` on `test-python` passing, so any tag-push triggers a workflow that can never reach the publish step — the same class of silent failure that left `v1.3.0` ungated on npm.

This PR is the first step in unblocking the `akf-format@1.2.10` release (PR #103).

## Verification
```
$ pytest tests/test_e2e_multi_agent.py::TestMultiAgentPipelineE2E::test_agent_card_to_delegation_to_certify -v
PASSED
```
Full Python suite: 1896 passed, 1 unrelated environmental failure (`test_scan_entire_tree` asserts > 20 files scanned in a tmp dir; not in CI's failure set).