### PR TITLE
Fix markdown stamp/extract roundtrip with nested lists (issue #105)

### DIFF
--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `akf-format` will be documented in this file.
 
 This project follows [semantic versioning](https://semver.org/).
 
+## [1.2.11] — 2026-05-25
+
+### Fixed
+- Markdown stamp → extract roundtrip on `.md` files with nested-list values (e.g. `evidence`) — the YAML parser was bubbling nested list items up into the parent list and silently dropping item-level keys that came after a nested list. Affected the headline format (used by the Obsidian plugin and every README demo). — #105
+
 ## [1.2.10] — 2026-05-24
 
 ### Fixed

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akf-format",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "mcpName": "io.github.HMAKT99/akf",
   "description": "AKF — Agent Knowledge Format SDK for TypeScript",
   "type": "module",

--- a/typescript/src/file.ts
+++ b/typescript/src/file.ts
@@ -168,39 +168,43 @@ function parseYamlList(lines: string[]): unknown[] {
   let i = 0;
 
   while (i < lines.length) {
-    const stripped = lines[i].trim();
+    const line = lines[i];
+    const stripped = line.trim();
     if (!stripped) { i++; continue; }
     if (!stripped.startsWith("- ")) { i++; continue; }
 
-    const itemIndent = indentLevel(lines[i]);
+    const itemIndent = indentLevel(line);
     const first = stripped.slice(2).trim();
 
-    if (first.includes(":")) {
-      // Dict item
-      const obj: Record<string, unknown> = {};
-      const colonIdx = first.indexOf(":");
-      obj[first.slice(0, colonIdx).trim()] = parseYamlValue(first.slice(colonIdx + 1).trim());
-      let j = i + 1;
-      while (j < lines.length) {
-        const nextLine = lines[j];
-        const ns = nextLine.trim();
-        if (!ns) { j++; continue; }
-        if (indentLevel(nextLine) > itemIndent && !ns.startsWith("- ")) {
-          if (ns.includes(":")) {
-            const ci = ns.indexOf(":");
-            obj[ns.slice(0, ci).trim()] = parseYamlValue(ns.slice(ci + 1).trim());
-          }
-          j++;
-        } else {
-          break;
-        }
+    // Gather every continuation line that belongs to this item:
+    // anything indented strictly deeper than the dash, plus interleaved blanks.
+    const childLines: string[] = [];
+    let j = i + 1;
+    while (j < lines.length) {
+      const next = lines[j];
+      const ns = next.trim();
+      if (!ns) { childLines.push(next); j++; continue; }
+      if (indentLevel(next) > itemIndent) {
+        childLines.push(next);
+        j++;
+      } else {
+        break;
       }
-      items.push(obj);
-      i = j;
+    }
+
+    if (first.includes(":")) {
+      // Dict item. Synthesize the first KV as a line at the same indent as the
+      // continuation children, then let parseYamlBlock handle the whole item —
+      // that way nested objects, nested lists, and KVs after a nested list all
+      // parse correctly (without re-implementing the YAML state machine here).
+      const refLine = childLines.find((l) => l.trim() !== "");
+      const childIndent = refLine !== undefined ? indentLevel(refLine) : itemIndent + 2;
+      const blockLines = [" ".repeat(childIndent) + first, ...childLines];
+      items.push(parseYamlBlock(blockLines));
     } else {
       items.push(parseYamlValue(first));
-      i++;
     }
+    i = j;
   }
   return items;
 }

--- a/typescript/tests/file.test.ts
+++ b/typescript/tests/file.test.ts
@@ -124,6 +124,46 @@ describe("stampFile", () => {
       stampFile(filepath, { evidence: 42 })
     ).toThrowError(/'evidence' must be a string or string\[\]/);
   });
+
+  it("should roundtrip markdown stamp -> extract with nested-list values (issue #105)", () => {
+    const filepath = join(tmpDir, "roundtrip.md");
+    writeFileSync(filepath, "# Hello\n", "utf-8");
+    const stamped = stampFile(filepath, { agent: "rt", evidence: "tests pass" });
+
+    const extracted = extract(filepath);
+    expect(extracted).not.toBeNull();
+    expect(extracted!.claims.length).toBe(1);
+    const ev = extracted!.claims[0].evidence;
+    expect(Array.isArray(ev)).toBe(true);
+    expect(ev!.length).toBe(1);
+    expect(ev![0].detail).toBe("tests pass");
+    expect(extracted!.claims[0].id).toBe(stamped.claims[0].id);
+  });
+
+  it("should roundtrip markdown with multiple claims, each carrying nested evidence (issue #105)", () => {
+    const filepath = join(tmpDir, "multi.md");
+    writeFileSync(filepath, "# X\n", "utf-8");
+    const unit = createMulti([
+      {
+        c: "A",
+        t: 0.9,
+        evidence: [
+          { type: "test_pass", detail: "a1", at: "2026-01-01T00:00:00Z" },
+          { type: "human_review", detail: "a2", at: "2026-01-01T00:00:00Z" },
+        ],
+      },
+      { c: "B", t: 0.5 },
+    ]);
+    embed(filepath, unit);
+
+    const x = extract(filepath);
+    expect(x!.claims.length).toBe(2);
+    expect(x!.claims[0].evidence!.length).toBe(2);
+    expect(x!.claims[0].evidence![0].detail).toBe("a1");
+    expect(x!.claims[0].evidence![1].detail).toBe("a2");
+    expect(x!.claims[1].c).toBe("B");
+    expect(x!.claims[1].evidence).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #105 — the headline format (markdown YAML frontmatter) was losing data on roundtrip.

## What broke

`stampFile()` writes correct native YAML to `.md` files, but the hand-rolled YAML parser in `extract()` mishandled list items whose value contained a nested list. Symptom for a single-evidence stamp:

```
extract().claims.length     // 2   (expected 1)
extract().claims[0].evidence // ""  (expected an array)
extract().claims[1]          // { type, detail, at }  ← leaked from nested list
```

Item-level keys after a nested list (e.g. `id` on the same claim) were silently dropped too.

Pre-existing since PR #96 introduced native YAML frontmatter (2026-04-06). No existing test caught it because `file.test.ts` exercised stamp/extract on `.akf` files, not `.md`.

## The fix

`parseYamlList` was running its own KV state machine per item, which couldn't descend into nested lists or recover after one. The block parser already does all of that correctly — the list parser just needed to delegate.

New shape: for each `- ` item, collect every continuation line indented deeper than the dash, synthesize the first KV at the same indent as the continuation lines, then call `parseYamlBlock` on the lot.

## Tests
- `tests/file.test.ts` — two new regressions:
  - single claim + single evidence string, full roundtrip
  - multi-claim, claim 0 carries two evidence entries, claim 1 carries none
- Full suite: 194/194 passing (was 192, +2 from this PR)

## Verification

Repro from issue #105 now passes:
```ts
const s = await stampFile('r.md', { agent: 'e2e', evidence: 'tests pass' });
const x = await extract('r.md');
x.claims.length;                     // 1 ✓
x.claims[0].evidence[0].detail;      // "tests pass" ✓
x.claims[0].id === s.claims[0].id;   // true ✓
```

Other formats (`.akf`, `.json`, `.html`, plain-text sidecar) verified unaffected.

Version bumped to `1.2.11`, CHANGELOG updated.