### PR TITLE
fix(markdown): round-trip claims that carry a nested evidence list

### DIFF
--- a/python/akf/formats/markdown.py
+++ b/python/akf/formats/markdown.py
@@ -196,26 +196,24 @@ def _parse_yaml_list(lines: List[str]) -> List[Any]:
         first = stripped[2:].strip()
 
         if ":" in first:
-            # Dict item starting on this line
-            obj: Dict[str, Any] = {}
-            k, v = first.split(":", 1)
-            obj[k.strip()] = _parse_yaml_value(v.strip())
-            # Collect continuation lines at deeper indent
+            # Dict item. Reconstruct the item body (the inline ``key: val`` plus
+            # every deeper-indented continuation line) and delegate to the block
+            # parser. This keeps nested structures owned by the item — e.g. a
+            # claim's ``evidence:`` list — instead of letting their ``- `` lines
+            # leak back into this sequence as bogus sibling items.
+            body_lines = [" " * (item_indent + 2) + first]
             j = i + 1
             while j < len(lines):
                 next_line = lines[j]
                 if not next_line.strip():
                     j += 1
                     continue
-                if _indent_level(next_line) > item_indent and not next_line.strip().startswith("- "):
-                    ns = next_line.strip()
-                    if ":" in ns:
-                        ck, cv = ns.split(":", 1)
-                        obj[ck.strip()] = _parse_yaml_value(cv.strip())
+                if _indent_level(next_line) > item_indent:
+                    body_lines.append(next_line)
                     j += 1
                 else:
                     break
-            items.append(obj)
+            items.append(_parse_yaml_block(body_lines))
             i = j
         else:
             items.append(_parse_yaml_value(first))

--- a/python/tests/test_formats/test_markdown.py
+++ b/python/tests/test_formats/test_markdown.py
@@ -129,6 +129,46 @@ class TestEmbedExtractWithFrontmatter:
         assert result is not None
         assert result["overall_trust"] == 0.9
 
+    def test_claim_with_nested_evidence_list_round_trips(
+        self, handler: MarkdownHandler, tmp_md
+    ) -> None:
+        # Regression: a claim carrying a nested ``evidence`` list of dicts must
+        # round-trip as a single claim. Previously the nested ``- `` lines leaked
+        # back into the claims sequence as bogus sibling claims (missing c/t),
+        # which crashed read/inspect/trust on every evidence-stamped Markdown file.
+        filepath = tmp_md("# Hello\n")
+        metadata = {
+            "akf": "1.0",
+            "claims": [
+                {
+                    "c": "Trust metadata for doc",
+                    "t": 0.7,
+                    "tier": 5,
+                    "ai": True,
+                    "evidence": [
+                        {
+                            "type": "other",
+                            "detail": "roundtrip test",
+                            "at": "2026-06-21T00:00:00+00:00",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        handler.embed(filepath, metadata)
+        result = handler.extract(filepath)
+
+        assert result is not None
+        assert len(result["claims"]) == 1
+        claim = result["claims"][0]
+        assert claim["c"] == "Trust metadata for doc"
+        assert claim["t"] == 0.7
+        assert isinstance(claim["evidence"], list)
+        assert len(claim["evidence"]) == 1
+        assert claim["evidence"][0]["type"] == "other"
+        assert claim["evidence"][0]["detail"] == "roundtrip test"
+
 
 # --------------------------------------------------------------------------
 # is_enriched


### PR DESCRIPTION
## What

`akf read`, `akf inspect`, and `akf trust` crashed with a Pydantic `ValidationError`
on **any Markdown file stamped with evidence** — i.e. the standard
`akf stamp <file.md> --evidence "..."` workflow.

## Root cause

Markdown stores AKF metadata as native YAML frontmatter and parses it back with a
small hand-rolled YAML reader. `_parse_yaml_list` reimplemented dict-item
continuation handling instead of reusing `_parse_yaml_block`, and that copy could not
descend into a **nested list inside a list item**. For a claim carrying an
`evidence:` list:

- the `evidence:` key was stored as an empty string (so `claim.evidence` came back as
  `""` instead of a list), and
- the evidence entries' `- ` lines fell through and were re-read by the outer loop as
  **bogus sibling claims** with no `c`/`t` fields.

`claims[1]` was then literally the evidence dict (`{"type": "other", ...}`), which
fails model validation — hence the crash.

## Fix

`_parse_yaml_list` now reconstructs each dict item's body (the inline `key: val` plus
every deeper-indented continuation line) and delegates to `_parse_yaml_block`, which
already handles nested lists and objects correctly. Nested structures stay owned by
their item instead of leaking into the sequence.

## Testing

- New regression test `test_claim_with_nested_evidence_list_round_trips` in
  `tests/test_formats/test_markdown.py` (embed → extract a claim with a nested
  `evidence` list; assert one claim survives and the evidence list is intact).
- `pytest tests/test_formats/test_markdown.py` → 22 passed.
- Full e2e verification: `akf stamp x.md --evidence "..."` then `read` / `inspect` /
  `trust` now succeed; the claim's `evidence` round-trips as
  `[{"type": "other", "detail": "...", "at": "..."}]`.
- Non-Markdown formats (txt/json/py, sidecar-based) were never affected and still pass.
