### PR TITLE
fix(scan): make --recursive/-r recurse instead of inverting

### DIFF
--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -520,12 +520,16 @@ def _trust_bar(count, total, width=20):
 
 @main.command("scan")
 @click.argument("file_or_dir", type=click.Path(exists=True))
-@click.option("--recursive", "-r", is_flag=True, default=True, help="Scan directories recursively (default: on)")
-@click.option("--no-recursive", is_flag=True, help="Scan only top-level files in directory")
+@click.option(
+    "--recursive/--no-recursive",
+    "-r/-R",
+    default=True,
+    help="Scan directories recursively (default: on; --no-recursive scans top-level only)",
+)
 @click.option("--max-files", "-n", default=10000, type=int, help="Maximum files to scan (default: 10000)")
 @click.option("--output", "-o", type=click.Path(), help="Export report (.html, .json, .csv, .md, .pdf)")
 @click.option("--open", "open_report", is_flag=True, help="Open report in browser after export")
-def scan_cmd(file_or_dir, recursive, no_recursive, max_files, output, open_report) -> None:
+def scan_cmd(file_or_dir, recursive, max_files, output, open_report) -> None:
     """Security scan any file or directory for AKF metadata."""
     from . import universal as akf_u
     from pathlib import Path
@@ -534,9 +538,6 @@ def scan_cmd(file_or_dir, recursive, no_recursive, max_files, output, open_repor
     if output:
         _export_report(file_or_dir, output, open_report, "scan")
         return
-
-    if no_recursive:
-        recursive = False
 
     target = Path(file_or_dir)
     if target.is_dir():

--- a/python/tests/test_scan_recursive_flag.py
+++ b/python/tests/test_scan_recursive_flag.py
@@ -1,0 +1,64 @@
+"""Regression tests for the ``akf scan`` recursion flag.
+
+``--recursive`` / ``-r`` was defined as ``is_flag=True, default=True`` which made
+passing the flag *disable* recursion — the opposite of its name. These tests pin the
+correct behaviour: recursive forms walk the whole tree, non-recursive forms stay at
+the top level.
+"""
+
+import re
+
+from click.testing import CliRunner
+
+from akf.cli import main
+
+
+def _stamp(runner: CliRunner, path) -> None:
+    res = runner.invoke(
+        main, ["stamp", str(path), "--agent", "claude-code", "--evidence", "t"]
+    )
+    assert res.exit_code == 0, res.output
+
+
+def _scanned_count(output: str) -> int:
+    m = re.search(r"(\d+) scanned", output)
+    assert m, "no scan count found in output:\n" + output
+    return int(m.group(1))
+
+
+def _build_tree(tmp_path) -> tuple:
+    """Two stamped files at the top level, three nested deeper."""
+    (tmp_path / "sub" / "deep").mkdir(parents=True)
+    top = [tmp_path / "a.txt", tmp_path / "b.txt"]
+    nested = [
+        tmp_path / "sub" / "c.txt",
+        tmp_path / "sub" / "deep" / "d.txt",
+        tmp_path / "sub" / "deep" / "e.txt",
+    ]
+    runner = CliRunner()
+    for p in top + nested:
+        p.write_text("x", encoding="utf-8")
+        _stamp(runner, p)
+    return len(top), len(top) + len(nested)
+
+
+def test_recursive_forms_walk_whole_tree(tmp_path) -> None:
+    n_top, total = _build_tree(tmp_path)
+    runner = CliRunner()
+
+    # Default is recursive.
+    assert _scanned_count(runner.invoke(main, ["scan", str(tmp_path)]).output) == total
+
+    # -r / --recursive must also recurse (regression: these used to scan top-level only).
+    for flag in ("-r", "--recursive"):
+        out = runner.invoke(main, ["scan", str(tmp_path), flag]).output
+        assert _scanned_count(out) == total, "{} should recurse".format(flag)
+
+
+def test_non_recursive_forms_stay_top_level(tmp_path) -> None:
+    n_top, total = _build_tree(tmp_path)
+    runner = CliRunner()
+
+    for flag in ("--no-recursive", "-R"):
+        out = runner.invoke(main, ["scan", str(tmp_path), flag]).output
+        assert _scanned_count(out) == n_top, "{} should scan top-level only".format(flag)


### PR DESCRIPTION
## What

`akf scan <dir> --recursive` / `-r` scanned **only the top level**, while the *default*
(no flag) recursed — the flag did the opposite of its name. In a 25-file nested tree:
`akf scan .` → 25, but `akf scan . -r` → 6.

## Root cause

`--recursive` / `-r` was declared `is_flag=True, default=True`. With a boolean flag
whose default is truthy, Click resolves the flag's presence to `False`, so passing
`-r` set `recursive=False`. A separate `--no-recursive` flag then layered on top.

## Fix

Replace the two separate options with Click's idiomatic boolean pair
`--recursive/--no-recursive` (default on, shorts `-r`/`-R`) and drop the now-redundant
`if no_recursive: recursive = False` branch. Behaviour after the fix:

| invocation | result |
|---|---|
| `scan dir` (default) | recursive |
| `scan dir -r` / `--recursive` | recursive |
| `scan dir --no-recursive` / `-R` | top-level only |

## Testing

- New `tests/test_scan_recursive_flag.py` (CliRunner) pins both directions: recursive
  forms walk a 2-top/3-nested tree (5 scanned), non-recursive forms stay top-level
  (2 scanned).
- `tests/test_e2e_integration.py` → 135 passed (the previously-failing
  `TestPhase14Volume::test_scan_entire_tree` now passes).
- Full suite: **1899 passed, 2 skipped** (was 1896 passed + 1 failed).
