### PR TITLE
chore(python): align SDK version to 1.2.11 to match npm

### DIFF
--- a/python/akf/__init__.py
+++ b/python/akf/__init__.py
@@ -278,7 +278,7 @@ def read(filepath):
         return meta
 
 
-__version__ = "1.2.5"
+__version__ = "1.2.11"
 __all__ = [
     # Models
     "AKF",

--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -15,7 +15,7 @@ from .trust import compute_all, effective_trust
 
 
 @click.group(invoke_without_command=True)
-@click.version_option(version="1.2.5", prog_name="akf")
+@click.version_option(version="1.2.11", prog_name="akf")
 @click.pass_context
 def main(ctx) -> None:
     """AKF — Agent Knowledge Format CLI."""

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "akf"
-version = "1.2.5"
+version = "1.2.11"
 description = "AKF — Agent Knowledge Format. Lightweight file format for AI-generated knowledge with built-in trust, provenance, and security."
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
## What

The Python SDK reported version **1.2.5** while the published npm package
`akf-format` is at **1.2.11**, so the two SDKs were out of sync.

## Change

Bump the Python SDK to **1.2.11** to match npm. Three references updated:

- `python/pyproject.toml` — `version`
- `python/akf/__init__.py` — `__version__`
- `python/akf/cli.py` — `@click.version_option` (the `akf --version` output)

The TypeScript package is already at 1.2.11; `core.ts`'s `AKF_VERSION = "1.0"` is the
AKF **format** spec version (not the package version) and is intentionally left as-is.

## Verification

- `akf --version` → `akf, version 1.2.11`; `akf.__version__` → `1.2.11`.
- `pytest tests/test_delta_cli.py tests/test_core.py` → 23 passed. No test hardcoded the old version.
