### PR TITLE
chore(release): bump akf + akf-format to 1.4.0

### DIFF
--- a/python/akf/__init__.py
+++ b/python/akf/__init__.py
@@ -278,7 +278,7 @@ def read(filepath):
         return meta
 
 
-__version__ = "1.2.11"
+__version__ = "1.4.0"
 __all__ = [
     # Models
     "AKF",

--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -15,7 +15,7 @@ from .trust import compute_all, effective_trust
 
 
 @click.group(invoke_without_command=True)
-@click.version_option(version="1.2.11", prog_name="akf")
+@click.version_option(version="1.4.0", prog_name="akf")
 @click.pass_context
 def main(ctx) -> None:
     """AKF — Agent Knowledge Format CLI."""

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "akf"
-version = "1.2.11"
+version = "1.4.0"
 description = "AKF — Agent Knowledge Format. Lightweight file format for AI-generated knowledge with built-in trust, provenance, and security."
 requires-python = ">=3.9"
 authors = [

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akf-format",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akf-format",
-      "version": "1.0.0",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akf-format",
-  "version": "1.2.11",
+  "version": "1.4.0",
   "mcpName": "io.github.HMAKT99/akf",
   "description": "AKF — Agent Knowledge Format SDK for TypeScript",
   "type": "module",


### PR DESCRIPTION
Aligns both SDKs to a single release version (1.4.0) ahead of publishing to PyPI and npm.

- `python/pyproject.toml`, `python/akf/__init__.py`, `python/akf/cli.py` → 1.4.0
- `typescript/package.json` (+ lock) → 1.4.0

Includes the markdown evidence round-trip fix (#107) and the scan --recursive flag fix (#108). Python suite (1900 passed) and npm vitest (194 passed) both green; `akf --version` reports 1.4.0.