### PR TITLE
feat(cli): add --json output to akf trust

### DIFF
--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -298,7 +298,8 @@ def inspect(file) -> None:
 @main.command()
 @click.argument("file", type=click.Path(exists=True))
 @click.option("--threshold", "-t", default=0.6, type=float, help="Trust threshold")
-def trust(file, threshold) -> None:
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def trust(file, threshold, as_json) -> None:
     """Compute effective trust for all claims."""
     from . import universal as akf_u
     meta = akf_u.extract(file)
@@ -307,6 +308,25 @@ def trust(file, threshold) -> None:
     else:
         unit = load(file)
     results = compute_all(unit)
+
+    if as_json:
+        payload = {
+            "file": file,
+            "threshold": threshold,
+            "claims": [
+                {
+                    "content": claim.content,
+                    "decision": result.decision,
+                    "score": round(result.score, 4),
+                    "confidence": claim.confidence,
+                    "tier": claim.authority_tier or 3,
+                    "breakdown": result.breakdown,
+                }
+                for claim, result in zip(unit.claims, results)
+            ],
+        }
+        click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+        return
 
     for claim, result in zip(unit.claims, results):
         if result.decision == "ACCEPT":

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -104,6 +104,16 @@ class TestTrustCmd:
         assert result.exit_code == 0
         assert "ACCEPT" in result.output or "REJECT" in result.output
 
+    def test_trust_json(self, runner, sample_file):
+        result = runner.invoke(main, ["trust", sample_file, "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["file"] == sample_file
+        assert isinstance(payload["claims"], list) and payload["claims"]
+        claim = payload["claims"][0]
+        assert set(claim) >= {"content", "decision", "score", "confidence", "tier", "breakdown"}
+        assert claim["decision"] in {"ACCEPT", "LOW", "REJECT"}
+
 
 class TestConsumeCmd:
     def test_consume(self, runner, sample_file):


### PR DESCRIPTION
Adds a `--json` flag to `akf trust` for machine-readable output.

```
akf trust file.md --json
```
emits:
```json
{
  "file": "file.md",
  "threshold": 0.6,
  "claims": [
    { "content": "...", "decision": "REJECT", "score": 0.26, "confidence": 0.7, "tier": 5, "breakdown": { ... } }
  ]
}
```

Default (colored) output is unchanged. Mirrors the existing `--json` flag on `akf read`. Adds `test_trust_json`; full `test_cli.py` passes (19).

Closes #7.