### PR TITLE
docs(readme): add TypeScript usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ result = akf.audit("report.akf", regulation="eu_ai_act")
 print(f"Compliant: {result.compliant}")
 ```
 
+**TypeScript / Node.js** (`akf-format`):
+
+```typescript
+import { create, validate, effectiveTrust, stampFile } from 'akf-format';
+
+// Create a trust-stamped unit from any AI output
+const unit = create('Revenue was $4.2B, up 12% YoY', 0.98, {
+  source: 'SEC 10-Q',
+  agent: 'claude-code',
+});
+
+// Validate against the AKF schema
+const { valid } = validate(unit);
+
+// Compute effective trust for a claim
+const trust = effectiveTrust(unit.claims[0]);
+console.log(`valid: ${valid}, score: ${trust.score}, decision: ${trust.decision}`);
+
+// Stamp trust metadata directly into a file (markdown, json, code, …)
+stampFile('report.md', { agent: 'claude-code', evidence: 'tests pass' });
+```
+
+> Full TypeScript API and more examples: [`typescript/README.md`](typescript/README.md).
+
 ## For AI Agents
 
 AKF is designed **agent-first**. One-line APIs for stamping, streaming, and auditing.

--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -298,7 +298,8 @@ def inspect(file) -> None:
 @main.command()
 @click.argument("file", type=click.Path(exists=True))
 @click.option("--threshold", "-t", default=0.6, type=float, help="Trust threshold")
-def trust(file, threshold) -> None:
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def trust(file, threshold, as_json) -> None:
     """Compute effective trust for all claims."""
     from . import universal as akf_u
     meta = akf_u.extract(file)
@@ -307,6 +308,25 @@ def trust(file, threshold) -> None:
     else:
         unit = load(file)
     results = compute_all(unit)
+
+    if as_json:
+        payload = {
+            "file": file,
+            "threshold": threshold,
+            "claims": [
+                {
+                    "content": claim.content,
+                    "decision": result.decision,
+                    "score": round(result.score, 4),
+                    "confidence": claim.confidence,
+                    "tier": claim.authority_tier or 3,
+                    "breakdown": result.breakdown,
+                }
+                for claim, result in zip(unit.claims, results)
+            ],
+        }
+        click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+        return
 
     for claim, result in zip(unit.claims, results):
         if result.decision == "ACCEPT":

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -104,6 +104,16 @@ class TestTrustCmd:
         assert result.exit_code == 0
         assert "ACCEPT" in result.output or "REJECT" in result.output
 
+    def test_trust_json(self, runner, sample_file):
+        result = runner.invoke(main, ["trust", sample_file, "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["file"] == sample_file
+        assert isinstance(payload["claims"], list) and payload["claims"]
+        claim = payload["claims"][0]
+        assert set(claim) >= {"content", "decision", "score", "confidence", "tier", "breakdown"}
+        assert claim["decision"] in {"ACCEPT", "LOW", "REJECT"}
+
 
 class TestConsumeCmd:
     def test_consume(self, runner, sample_file):


### PR DESCRIPTION
The root README had Python examples + the npm install line but no TypeScript code. Adds a TS Quickstart block (`create` / `validate` / `effectiveTrust` / `stampFile`) alongside the Python one, plus a pointer to the full `typescript/README.md`.

All snippets verified against the published `akf-format@1.4.0`.

Closes #8.