### PR TITLE
feat(check): akf check — one-line agent trust check

### DIFF
--- a/packages/mcp-server-akf/mcp_server_akf/server.py
+++ b/packages/mcp-server-akf/mcp_server_akf/server.py
@@ -1,6 +1,7 @@
 """MCP server implementation for AKF — Agent Knowledge Format.
 
-Exposes 9 tools via Model Context Protocol:
+Exposes 10 tools via Model Context Protocol:
+  - check_file: One-line trust check — can an agent build on this file?
   - create_claim: Create AKF trust metadata
   - validate_file: Validate an .akf file
   - scan_file: Security scan any file
@@ -27,6 +28,16 @@ from mcp.types import Tool, TextContent
 # ---------------------------------------------------------------------------
 # Tool implementations
 # ---------------------------------------------------------------------------
+
+def check_file(path: str, threshold: float = 0.6) -> dict:
+    """One-line trust check: can an agent build on this file without re-verifying?"""
+    from akf.check import check_file as _check
+
+    result = _check(path, threshold=threshold)
+    payload = result.to_dict()
+    payload["summary"] = result.summary_line()
+    return payload
+
 
 def create_claim(content: str, confidence: float, source: str | None = None, ai_generated: bool = True) -> dict:
     """Create an AKF claim and return as JSON."""
@@ -159,6 +170,18 @@ def detect_threats(path: str) -> dict:
 
 TOOLS = [
     Tool(
+        name="check_file",
+        description="One-line trust check before building on a file. Returns OK (fresh stamp, trust above threshold — skip re-verification), LOW (trust below threshold), STALE (modified after stamping or claims expired — re-verify), or UNSTAMPED (no metadata). Use this before re-reading, re-testing, or re-deriving work another agent already verified.",
+        inputSchema={
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+                "path": {"type": "string", "description": "Path to the file to check"},
+                "threshold": {"type": "number", "minimum": 0, "maximum": 1, "default": 0.6, "description": "Trust threshold for OK vs LOW"},
+            },
+        },
+    ),
+    Tool(
         name="create_claim",
         description="Create an AKF claim with trust metadata. Returns a JSON object with the claim, trust score, and provenance.",
         inputSchema={
@@ -275,6 +298,7 @@ TOOLS = [
 
 # Map tool names to handler functions
 HANDLERS = {
+    "check_file": check_file,
     "create_claim": create_claim,
     "validate_file": validate_file,
     "scan_file": scan_file,

--- a/python/akf/__init__.py
+++ b/python/akf/__init__.py
@@ -52,6 +52,7 @@ from .data import load_dataset, quality_report, merge, filter_claims
 from .report import enterprise_report, EnterpriseReport, FileReport, register_renderer, RENDERERS
 from .knowledge_base import KnowledgeBase
 from .stamp import stamp, stamp_file
+from .check import check_file, CheckResult
 from .certify import (
     certify_file, certify_directory, certify_team,
     CertifyResult, CertifyReport, AgentCertifyReport, TeamCertifyReport,
@@ -414,6 +415,8 @@ __all__ = [
     # Stamp & Git
     "stamp",
     "stamp_file",
+    "check_file",
+    "CheckResult",
     "stamp_commit",
     "read_commit",
     "trust_log",

--- a/python/akf/check.py
+++ b/python/akf/check.py
@@ -1,0 +1,194 @@
+"""Fast trust check for agent consumption.
+
+`check_file` answers one question in one line: can an agent trust this
+file's stamped verification state, or does it need to re-verify?
+
+Statuses:
+    OK        — fresh stamp, trust at or above threshold. Safe to build on.
+    LOW       — stamped and fresh, but effective trust below threshold.
+    STALE     — file modified after it was stamped, or claims expired.
+    UNSTAMPED — no AKF metadata found.
+
+Exit codes (CLI): OK=0, LOW/STALE=1, UNSTAMPED=2.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from .models import AKF, Claim
+from .trust import effective_trust, is_expired
+
+# Seconds of slack between the stamp timestamp and the file mtime — stamping
+# rewrites the file, so the mtime always lands slightly after `created`.
+_MTIME_TOLERANCE_S = 10
+
+# Objective verification receipts upgrade a claim's authority tier: a stamp
+# backed by a test run or a human review is no longer bare AI inference
+# (tier 5), even though the content itself is AI-generated. Weak signals
+# (lint, type check) alone don't clear the default threshold; test runs and
+# human review do.
+_EVIDENCE_TIER_FLOOR = {
+    "human_review": 1,
+    "test_pass": 2,
+    "ci_pass": 2,
+    "type_check": 3,
+    "lint_clean": 3,
+}
+
+
+@dataclass
+class CheckResult:
+    """Result of a trust check on a single file."""
+
+    file: str
+    status: str  # OK | LOW | STALE | UNSTAMPED
+    exit_code: int
+    trust: Optional[float] = None
+    threshold: float = 0.6
+    agent: Optional[str] = None
+    model: Optional[str] = None
+    age_days: Optional[int] = None
+    claims: int = 0
+    evidence: List[str] = field(default_factory=list)
+    reason: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "file": self.file,
+            "status": self.status,
+            "exit_code": self.exit_code,
+            "trust": self.trust,
+            "threshold": self.threshold,
+            "agent": self.agent,
+            "model": self.model,
+            "age_days": self.age_days,
+            "claims": self.claims,
+            "evidence": self.evidence,
+            "reason": self.reason,
+        }
+
+    def summary_line(self) -> str:
+        """One-line, ~20-token summary designed for agent context windows."""
+        parts = [self.status]
+        if self.trust is not None:
+            parts.append(f"trust={self.trust:.2f}")
+        if self.agent:
+            parts.append(f"agent={self.agent}")
+        if self.evidence:
+            parts.append("evidence=" + ",".join(self.evidence))
+        if self.age_days is not None:
+            parts.append(f"age={self.age_days}d")
+        if self.claims:
+            parts.append(f"claims={self.claims}")
+        if self.reason:
+            parts.append(f"reason={self.reason}")
+        return " ".join(parts)
+
+
+def _parse_ts(value: str) -> Optional[datetime]:
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _evidence_types(unit: AKF) -> List[str]:
+    types: List[str] = []
+    for claim in unit.claims:
+        for ev in claim.evidence or []:
+            ev_type = getattr(ev, "type", None) or "other"
+            if ev_type not in types:
+                types.append(ev_type)
+    return types
+
+
+def _claim_score(claim: Claim) -> float:
+    """Effective trust with evidence-aware authority.
+
+    Verification receipts (tests, type checks, human review) floor the
+    authority tier — see _EVIDENCE_TIER_FLOOR.
+    """
+    floors = [
+        _EVIDENCE_TIER_FLOOR[ev.type]
+        for ev in (claim.evidence or [])
+        if getattr(ev, "type", None) in _EVIDENCE_TIER_FLOOR
+    ]
+    if floors:
+        tier = claim.authority_tier if claim.authority_tier is not None else 3
+        floored = min(min(floors), tier)
+        if floored != tier:
+            claim = claim.model_copy(update={"authority_tier": floored})
+    return effective_trust(claim).score
+
+
+def check_file(filepath: str, threshold: float = 0.6) -> CheckResult:
+    """Check whether an agent can trust a file's stamped state.
+
+    Reads AKF metadata (inline or sidecar), computes effective trust,
+    and compares the stamp timestamp against the file's mtime to catch
+    modifications made after stamping.
+    """
+    from . import universal
+    from .core import load
+
+    meta = universal.extract(filepath)
+    if meta is not None:
+        unit = AKF(**meta)
+    elif filepath.endswith(".akf"):
+        try:
+            unit = load(filepath)
+        except Exception:
+            unit = None
+    else:
+        unit = None
+
+    if unit is None:
+        return CheckResult(
+            file=filepath, status="UNSTAMPED", exit_code=2,
+            threshold=threshold, reason="no_metadata",
+        )
+
+    scores = [_claim_score(claim) for claim in unit.claims]
+    overall = round(min(scores), 4) if scores else 0.0
+
+    stamped_at = _parse_ts(unit.created) if unit.created else None
+    age_days: Optional[int] = None
+    if stamped_at is not None:
+        age_days = max(0, (datetime.now(timezone.utc) - stamped_at).days)
+
+    base = dict(
+        file=filepath,
+        trust=overall,
+        threshold=threshold,
+        agent=unit.agent,
+        model=unit.model,
+        age_days=age_days,
+        claims=len(unit.claims),
+        evidence=_evidence_types(unit),
+    )
+
+    # Staleness: the file changed after it was stamped, or claims expired.
+    if stamped_at is not None:
+        try:
+            mtime = datetime.fromtimestamp(os.path.getmtime(filepath), tz=timezone.utc)
+            if (mtime - stamped_at).total_seconds() > _MTIME_TOLERANCE_S:
+                return CheckResult(
+                    status="STALE", exit_code=1,
+                    reason="modified_after_stamp", **base,
+                )
+        except OSError:
+            pass
+    if any(is_expired(claim) for claim in unit.claims):
+        return CheckResult(status="STALE", exit_code=1, reason="claims_expired", **base)
+
+    if overall < threshold:
+        return CheckResult(status="LOW", exit_code=1, reason="below_threshold", **base)
+
+    return CheckResult(status="OK", exit_code=0, **base)

--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -143,6 +143,30 @@ def read_cmd(file, as_json) -> None:
             click.echo(f"    {actor} — {action} @ {ts}")
 
 
+@main.command("check")
+@click.argument("file", type=click.Path(exists=True))
+@click.option("--threshold", "-t", default=0.6, type=float, help="Trust threshold")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def check_cmd(file, threshold, as_json) -> None:
+    """One-line trust check — can an agent build on this file?
+
+    Prints OK, LOW, STALE, or UNSTAMPED with trust, agent, evidence, and age.
+    Exit codes: 0=OK, 1=LOW/STALE (re-verify), 2=UNSTAMPED.
+    """
+    from .check import check_file
+
+    result = check_file(file, threshold=threshold)
+
+    if as_json:
+        click.echo(json.dumps(result.to_dict(), indent=2, ensure_ascii=False))
+    else:
+        color = {"OK": "green", "LOW": "yellow", "STALE": "yellow"}.get(result.status, "red")
+        click.secho(result.summary_line(), fg=color)
+
+    if result.exit_code:
+        raise SystemExit(result.exit_code)
+
+
 @main.command("create")
 @click.argument("file", type=click.Path(), required=False)
 @click.option("--claim", "-c", multiple=True, help="Claim content")

--- a/python/akf/stamp.py
+++ b/python/akf/stamp.py
@@ -46,6 +46,7 @@ _EVIDENCE_PATTERNS = [
     (r"human.*review", "human_review"),
     (r"code.*review", "human_review"),
     (r"approved\s*by", "human_review"),
+    (r"reviewed\s*by", "human_review"),
     (r"peer.*review", "human_review"),
 ]
 

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -1,0 +1,139 @@
+"""Tests for akf check — the one-line agent trust check."""
+
+import json
+import os
+import time
+import tempfile
+
+import pytest
+from click.testing import CliRunner
+
+from akf.check import check_file
+from akf.cli import main
+from akf.stamp import stamp_file
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def stamped_md(tmp_path):
+    """A markdown file stamped with strong evidence."""
+    path = tmp_path / "report.md"
+    path.write_text("# Report\n\nAll good.\n")
+    stamp_file(
+        str(path),
+        agent="claude-code",
+        trust_score=0.9,
+        evidence=["42/42 tests passed"],
+    )
+    return str(path)
+
+
+class TestCheckFile:
+    def test_ok_on_fresh_stamp(self, stamped_md):
+        result = check_file(stamped_md)
+        assert result.status == "OK"
+        assert result.exit_code == 0
+        assert result.agent == "claude-code"
+        assert result.trust is not None and result.trust >= 0.6
+        assert "test_pass" in result.evidence
+        assert result.age_days == 0
+
+    def test_unstamped(self, tmp_path):
+        path = tmp_path / "plain.md"
+        path.write_text("no metadata here\n")
+        result = check_file(str(path))
+        assert result.status == "UNSTAMPED"
+        assert result.exit_code == 2
+        assert result.reason == "no_metadata"
+
+    def test_stale_after_modification(self, stamped_md):
+        # Modify the file well past the mtime tolerance window.
+        with open(stamped_md, "a") as f:
+            f.write("\nedited later\n")
+        future = time.time() + 3600
+        os.utime(stamped_md, (future, future))
+        result = check_file(stamped_md)
+        assert result.status == "STALE"
+        assert result.exit_code == 1
+        assert result.reason == "modified_after_stamp"
+
+    def test_low_trust(self, tmp_path):
+        path = tmp_path / "guess.md"
+        path.write_text("# Guess\n")
+        stamp_file(str(path), agent="claude-code", trust_score=0.2)
+        result = check_file(str(path))
+        assert result.status == "LOW"
+        assert result.exit_code == 1
+        assert result.reason == "below_threshold"
+
+    def test_bare_ai_stamp_is_low(self, tmp_path):
+        # No verification evidence: stays at tier 5 (AI inference) -> LOW.
+        path = tmp_path / "bare.md"
+        path.write_text("# Bare\n")
+        stamp_file(str(path), agent="claude-code", trust_score=0.9)
+        result = check_file(str(path))
+        assert result.status == "LOW"
+
+    def test_default_stamp_with_tests_is_ok(self, tmp_path):
+        # The documented flow: akf stamp <file> --evidence "tests pass"
+        # (default confidence 0.7) must clear the default threshold.
+        path = tmp_path / "default.md"
+        path.write_text("# D\n")
+        stamp_file(str(path), agent="claude-code", evidence=["tests pass"])
+        result = check_file(str(path))
+        assert result.status == "OK"
+
+    def test_weak_evidence_alone_stays_low(self, tmp_path):
+        path = tmp_path / "linted.md"
+        path.write_text("# L\n")
+        stamp_file(str(path), agent="claude-code", evidence=["lint: clean"])
+        assert check_file(str(path)).status == "LOW"
+
+    def test_human_review_scores_above_tests(self, tmp_path):
+        tested = tmp_path / "tested.md"
+        tested.write_text("# T\n")
+        stamp_file(str(tested), agent="claude-code", trust_score=0.9,
+                   evidence=["42/42 tests passed"])
+        reviewed = tmp_path / "reviewed.md"
+        reviewed.write_text("# R\n")
+        stamp_file(str(reviewed), agent="claude-code", trust_score=0.9,
+                   evidence=["reviewed by @sarah"])
+        assert check_file(str(reviewed)).trust > check_file(str(tested)).trust
+
+    def test_threshold_is_respected(self, tmp_path):
+        path = tmp_path / "mid.md"
+        path.write_text("# Mid\n")
+        stamp_file(str(path), agent="claude-code", trust_score=0.9)
+        strict = check_file(str(path), threshold=0.99)
+        assert strict.status == "LOW"
+
+    def test_summary_line_is_compact(self, stamped_md):
+        line = check_file(stamped_md).summary_line()
+        assert line.startswith("OK trust=")
+        assert "agent=claude-code" in line
+        assert len(line) < 120
+
+
+class TestCheckCmd:
+    def test_cli_ok_exit_zero(self, runner, stamped_md):
+        result = runner.invoke(main, ["check", stamped_md])
+        assert result.exit_code == 0
+        assert result.output.startswith("OK ")
+
+    def test_cli_unstamped_exit_two(self, runner, tmp_path):
+        path = tmp_path / "plain.txt"
+        path.write_text("nothing\n")
+        result = runner.invoke(main, ["check", str(path)])
+        assert result.exit_code == 2
+        assert "UNSTAMPED" in result.output
+
+    def test_cli_json(self, runner, stamped_md):
+        result = runner.invoke(main, ["check", stamped_md, "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["status"] == "OK"
+        assert payload["agent"] == "claude-code"


### PR DESCRIPTION
## What

New `akf check <file>` command: a one-line, ~20-token trust check designed for agent consumption. It answers the question **"can an agent build on this file without re-verifying it?"**

```
$ akf check report.md
OK trust=0.65 agent=claude-code evidence=test_pass age=0d claims=1
```

| Status | Exit | Meaning |
|--------|------|---------|
| `OK` | 0 | Fresh stamp, trust ≥ threshold — safe to build on |
| `LOW` | 1 | Stamped but effective trust below threshold |
| `STALE` | 1 | File modified after stamping, or claims expired |
| `UNSTAMPED` | 2 | No AKF metadata found |

`--json` emits the full structured result; `--threshold` adjusts the gate (default 0.6, matching `akf trust`).

## Why

A stamp costs ~15 tokens; re-verifying costs thousands. This is the read-path payoff that makes stamping worth it: the next agent (or session) checks the stamp instead of re-running verification.

## Evidence-aware authority

Bare AI stamps are tier 5 (weight 0.30) and stay LOW — correctly. But a stamp carrying verification receipts isn't bare inference, so `check` floors the authority tier by evidence type: `human_review` → 1, `test_pass`/`ci_pass` → 2, `type_check`/`lint_clean` → 3. Result: unverified stamp = LOW, test-backed = OK, human-reviewed = strong OK.

## Also

- `check_file` added as the 10th MCP tool so any MCP agent can gate on it
- fix: `reviewed by @user` now classifies as `human_review` (was documented but missing from patterns)
- `akf.check_file` / `akf.CheckResult` exported in the Python API

## Testing

- 13 new tests in `python/tests/test_check.py` (statuses, exit codes, thresholds, evidence gradient, JSON output)
- Full suite: 1912 passed, 2 skipped
- MCP handler exercised directly (10 tools listed, `check_file` returns OK on a test-evidence stamp)