### PR TITLE
docs: reposition around the agent read path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,24 +1,52 @@
+---
+akf:
+  v: "1.0"
+  claims:
+    - c: Trust metadata for CLAUDE.md
+      t: 0.7
+      id: cf117d0c
+      src: unspecified
+      tier: 5
+      ver: false
+      ai: true
+      evidence:
+        - type: other
+          detail: "docs reviewed, protocol matches shipped akf check behavior"
+          at: "2026-07-02T16:52:28.182634+00:00"
+  id: "akf-c8cf5407d8a6"
+  agent: "claude-code"
+  at: "2026-07-02T16:52:28.183459+00:00"
+  label: public
+  inherit: true
+  ext: false
+  hash: "sha256:2cc31b8895ecb034"
+  sv: "1.1"
+---
 # AKF — Agent Knowledge Format
 
-AKF is the trust metadata standard for AI-generated content. When you create or modify files, stamp them with trust metadata so every output carries provenance.
+AKF is the trust metadata standard for AI-generated content. Stamps are notes agents leave for the next agent: what was done, what was verified, and how much to trust it. A stamp costs ~15 tokens; re-verifying costs thousands.
 
-## Rules
+## The protocol
 
-### After creating or modifying files
+### Before building on an existing file — check it
+```bash
+akf check <file>
+```
+- `OK` — fresh stamp with verified evidence. Build on it; skip re-verification.
+- `STALE` — modified after stamping. Re-verify before trusting.
+- `LOW` — stamped but unverified (no test/review evidence). Verify before trusting.
+- `UNSTAMPED` — no metadata. Treat as unverified.
+
+### After creating or modifying files — stamp what you verified
 ```bash
 akf stamp <file> --agent claude-code --evidence "<evidence>"
 ```
-Evidence examples: "tests pass", "docs reviewed", "refactored from existing code", "generated from spec"
+Evidence is auto-classified and drives trust: `"42/42 tests passed"` (test_pass), `"mypy: 0 errors"` (type_check), `"reviewed by @user"` (human_review), `"CI green"` (ci_pass). Only claim evidence you actually observed — a stamp that says tests passed when they didn't poisons every agent that trusts it.
 
-### After completing a task with commits
+### Deeper inspection when needed
 ```bash
-akf stamp <file> --agent claude-code --evidence "<summary of evidence>"
-```
-
-### When working with existing AKF-stamped files
-```bash
-akf read <file>          # Check existing trust metadata before modifying
-akf inspect <file>       # See detailed trust scores
+akf read <file>          # Full trust metadata
+akf inspect <file>       # Pretty-printed trust scores
 ```
 
 ### Classification
@@ -27,6 +55,7 @@ akf inspect <file>       # See detailed trust scores
 - Default is `internal`
 
 ## Available Commands
+- `akf check <file>` — One-line trust check (OK/LOW/STALE/UNSTAMPED, exit codes 0/1/2)
 - `akf stamp <file>` — Add trust metadata to any file
 - `akf read <file>` — Read trust metadata from any file
 - `akf inspect <file>` — Pretty-print trust scores

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ _akf: '{"v":"1.0","claims":[{"c":"Trust metadata for README.md","t":0.7,"id":"19
 <h1 align="center">AKF — The AI Native File Format</h1>
 
 <p align="center">
-  <strong>Trust scores · Source provenance · Security classification · Compliance readiness</strong><br/>
-  Embeds natively into DOCX, PDF, XLSX, images, code, and all major formats.<br/>
-  Think EXIF for AI — ~15 tokens of JSON that travel with your files.
+  <strong>A stamp costs ~15 tokens. Re-verifying costs 15,000.</strong><br/>
+  Think EXIF for AI — trust metadata that travels with every AI-generated file,<br/>
+  so the next agent (or human) knows what it can build on.
 </p>
 
 <p align="center">
@@ -46,38 +46,50 @@ _akf: '{"v":"1.0","claims":[{"c":"Trust metadata for README.md","t":0.7,"id":"19
 
 ---
 
-## The Problem
+## Paste this to your agent
 
-AI generates reports, code, docs, images — and **none of it carries provenance.** Your team opens a file with no idea: Who made it? AI or human? Can we trust it? Is it compliant?
+Don't install AKF yourself — let your agent do it. Paste this into Claude Code, Cursor, OpenClaw, or any coding agent:
 
-**EU AI Act Article 50 takes effect August 2, 2026.** After that, AI-generated content must carry transparency metadata. Penalties: up to EUR 35M / 7% of global turnover.
+```
+Install AKF (pip install akf, or pipx install akf) and set it up: run `akf init --git-hooks`.
+From now on:
+- After you create or modify a file, stamp it:
+    akf stamp <file> --agent <your-id> --evidence "<what you verified, e.g. 42/42 tests passed>"
+- Before building on any existing file, check it first:
+    akf check <file>
+  OK = fresh stamp with verified evidence, skip re-verification. STALE/LOW/UNSTAMPED = verify before trusting.
+If you support MCP, also register the server: {"mcpServers":{"akf":{"command":"python","args":["-m","mcp_server_akf"]}}}
+```
 
-## The Solution
+Your agent installs its own provenance layer — and every file it touches carries trust metadata from then on.
 
-AKF is the **AI native file format** — ~15 tokens of JSON that embed into any file:
+## Why agents need this
 
-| What | How |
+Agents redo work constantly: re-read files, re-run tests, re-derive conclusions — because nothing tells them what was already verified. A stamp is cached verification state:
+
+```console
+# Session 1 — agent fixes auth, tests pass
+$ akf stamp auth.py --agent claude-code --evidence "42/42 tests passed"
+
+# Session 2 — tomorrow, any agent, any tool
+$ akf check auth.py
+OK trust=0.65 agent=claude-code evidence=test_pass age=1d claims=1
+# → build on it, skip re-verification
+
+# Someone edits auth.py without re-testing
+$ akf check auth.py
+STALE trust=0.65 agent=claude-code evidence=test_pass age=1d claims=1 reason=modified_after_stamp
+# → re-verify before trusting (exit code 1 — gate CI or hooks on it)
+```
+
+Stamps are trail markers agents leave for other agents — across sessions, across tools (Claude Code → Cursor → Copilot), across teams. Humans get the same trail: who made this file, AI or human, was it tested, can we trust it.
+
+| What travels with the file | How |
 |------|-----|
-| **Trust score** | 0–1 confidence based on source tier |
+| **Trust score** | 0–1 confidence, weighted by evidence and source tier |
+| **Verification evidence** | tests passed, type check clean, human reviewed — with timestamps |
 | **Source provenance** | SEC filing → analyst → AI agent chain |
 | **Compliance** | One command: `akf audit file --regulation eu_ai_act` |
-
-```
-AI generates content → AKF stamps trust metadata → Anyone can verify it
-```
-
-### vs Alternatives
-
-| | AKF | C2PA | Watermarking | Manual tracking |
-|---|:---:|:---:|:---:|:---:|
-| Works on documents/code | ✅ | ❌ (media only) | ❌ | ⚠️ |
-| No Certificate Authority needed | ✅ | ❌ | ✅ | ✅ |
-| Trust scores | ✅ | ❌ | ❌ | ❌ |
-| Source provenance chain | ✅ | ✅ | ❌ | ⚠️ |
-| Compliance auditing | ✅ | ❌ | ❌ | ❌ |
-| ~15 tokens (LLM-friendly) | ✅ | ❌ | N/A | N/A |
-| 20+ file formats | ✅ | ⚠️ (media) | ⚠️ (text) | ❌ |
-| Free & open source | ✅ | ⚠️ | Varies | ✅ |
 
 ## Quickstart
 
@@ -92,13 +104,19 @@ akf doctor         # Check your install — detects PATH issues and guides setup
 > - Install with pipx: `pipx install akf` (recommended — auto-handles PATH)
 > - **Windows:** use `python3 -m akf` or install via `pipx`
 
+```bash
+# The core loop — stamp what you verified, check before you trust
+akf stamp auth.py --agent claude-code --evidence "42/42 tests passed"
+akf check auth.py        # OK trust=0.65 agent=claude-code evidence=test_pass age=0d
+```
+
 ```python
 import akf
 
-# Stamp trust metadata onto any AI output
-akf.stamp("Revenue was $4.2B, up 12% YoY",
-          confidence=0.98, source="SEC 10-Q",
-          agent="claude-code", model="claude-sonnet-4-20250514")
+# Same loop from Python
+akf.stamp_file("auth.py", agent="claude-code", evidence=["42/42 tests passed"])
+result = akf.check_file("auth.py")
+print(result.summary_line())   # OK trust=0.65 agent=claude-code evidence=test_pass age=0d claims=1
 
 # Embed into Office docs, PDFs, images — any format
 akf.embed("report.docx", claims=[...], classification="confidential")
@@ -134,12 +152,18 @@ stampFile('report.md', { agent: 'claude-code', evidence: 'tests pass' });
 
 ## For AI Agents
 
-AKF is designed **agent-first**. One-line APIs for stamping, streaming, and auditing.
+AKF is designed **agent-first**. One-line APIs for checking, stamping, streaming, and auditing.
 
 ```python
 import akf
 
-# Stamp with evidence (auto-detected: test_pass, type_check, etc.)
+# Check before you trust — can I build on this file without re-verifying?
+result = akf.check_file("auth.py")
+if result.status == "OK":      # fresh stamp, verified evidence
+    ...                        # skip re-verification, save the tokens
+# LOW / STALE / UNSTAMPED → verify before trusting
+
+# Stamp with evidence (auto-detected: test_pass, type_check, human_review, etc.)
 akf.stamp("Fixed auth bypass", kind="code_change",
           evidence=["42/42 tests passed", "mypy: 0 errors"],
           agent="claude-code", model="claude-sonnet-4-20250514")
@@ -216,7 +240,7 @@ pip install ./packages/mcp-server-akf
 }
 ```
 
-**9 MCP tools:** `create_claim` · `validate_file` · `scan_file` · `trust_score` · `stamp_file` · `audit_file` · `embed_file` · `extract_file` · `detect_threats`
+**10 MCP tools:** `check_file` · `create_claim` · `validate_file` · `scan_file` · `trust_score` · `stamp_file` · `audit_file` · `embed_file` · `extract_file` · `detect_threats`
 
 ## Ambient Trust
 
@@ -230,7 +254,7 @@ AKF works where AI agents work. Drop a config file, and every AI-generated file 
 | **GitHub Copilot** | Reads `.github/copilot-instructions.md` (native) + shell hook for CLI |
 | **OpenAI Codex** | Reads `AGENTS.md` — stamps files in cloud sandbox and local |
 | **Manus / Other Agents** | MCP server + shell hook — works with any agent that supports MCP or CLI |
-| **Any MCP agent** | 9 MCP tools — stamp, audit, embed, extract, detect, validate, scan, trust, create |
+| **Any MCP agent** | 10 MCP tools — check, stamp, audit, embed, extract, detect, validate, scan, trust, create |
 | **Any CLI tool** | `eval "$(akf shell-hook)"` — intercepts `claude`, `chatgpt`, `aider`, `openclaw`, `ollama`, `manus` |
 
 **The trust pipeline:**
@@ -259,6 +283,7 @@ AKF provides [agent skill files](skills/) that AI agents can discover and use. D
 
 | Skill | What it does |
 |-------|-------------|
+| [`check.md`](skills/check.md) | Check a file's trust before building on it |
 | [`stamp.md`](skills/stamp.md) | Stamp trust metadata onto AI outputs |
 | [`audit.md`](skills/audit.md) | Audit files for regulatory compliance |
 | [`scan.md`](skills/scan.md) | Security scan files and directories |
@@ -375,6 +400,10 @@ akf doctor                   # Check installation health
 akf create report.akf \
   --claim "Revenue $4.2B" --trust 0.98 --src "SEC 10-Q" \
   --by sarah@acme.com --label confidential
+
+# ── Check before you trust ──
+akf check auth.py            # One line: OK / LOW / STALE / UNSTAMPED
+akf check auth.py --json     # Structured output; exit codes 0/1/2 for gating
 
 # ── Validate & inspect ──
 akf validate report.akf
@@ -494,6 +523,29 @@ See [LLM-PROMPT.md](spec/LLM-PROMPT.md) for a full system prompt.
 | [LLM Integration](docs/llm-integration.md) | Prompting strategies |
 | [EU AI Act](docs/compliance/eu-ai-act-mapping.md) | Compliance mapping |
 | [NIST AI RMF](docs/compliance/nist-ai-rmf-mapping.md) | Framework mapping |
+
+## vs Alternatives
+
+| | AKF | C2PA | Watermarking | Manual tracking |
+|---|:---:|:---:|:---:|:---:|
+| Works on documents/code | ✅ | ❌ (media only) | ❌ | ⚠️ |
+| No Certificate Authority needed | ✅ | ❌ | ✅ | ✅ |
+| Trust scores | ✅ | ❌ | ❌ | ❌ |
+| Source provenance chain | ✅ | ✅ | ❌ | ⚠️ |
+| Compliance auditing | ✅ | ❌ | ❌ | ❌ |
+| ~15 tokens (LLM-friendly) | ✅ | ❌ | N/A | N/A |
+| 20+ file formats | ✅ | ⚠️ (media) | ⚠️ (text) | ❌ |
+| Free & open source | ✅ | ⚠️ | Varies | ✅ |
+
+## Compliance
+
+**EU AI Act Article 50 takes effect August 2, 2026** — AI-generated content must carry transparency metadata (penalties up to EUR 35M / 7% of global turnover). Files stamped with AKF already carry it:
+
+```bash
+akf audit report.docx --regulation eu_ai_act
+```
+
+Mappings for [EU AI Act](docs/compliance/eu-ai-act-mapping.md) and [NIST AI RMF](docs/compliance/nist-ai-rmf-mapping.md).
 
 ## Contributing
 

--- a/skills/check.md
+++ b/skills/check.md
@@ -1,0 +1,70 @@
+---
+akf:
+  v: "1.0"
+  claims:
+    - c: Trust metadata for skills/check.md
+      t: 0.7
+      id: e00e890c
+      src: unspecified
+      tier: 5
+      ver: false
+      ai: true
+      evidence:
+        - type: other
+          detail: "docs reviewed, matches shipped CLI behavior"
+          at: "2026-07-02T16:52:28.328391+00:00"
+  id: "akf-bda73947450c"
+  agent: "claude-code"
+  at: "2026-07-02T16:52:28.328612+00:00"
+  label: public
+  inherit: true
+  ext: false
+  hash: "sha256:6ce05b15b41d3215"
+  sv: "1.1"
+---
+# Skill: Check Before You Trust
+
+Check a file's trust metadata before building on it — one line, ~20 tokens, so you can skip re-verification when work is already verified.
+
+## When to use
+
+- Before modifying or extending a file another agent (or a past session) produced
+- Before re-running tests, re-reading, or re-deriving something that may already be verified
+- When deciding whether to trust a file handed off from another tool (Cursor, Copilot, Claude Code)
+
+## CLI
+
+```bash
+akf check <file>
+# OK trust=0.65 agent=claude-code evidence=test_pass age=1d claims=1
+
+akf check <file> --json          # structured output
+akf check <file> --threshold 0.8 # stricter gate
+```
+
+## How to act on the result
+
+| Status | Exit | Action |
+|--------|------|--------|
+| `OK` | 0 | Fresh stamp with verified evidence — build on it, skip re-verification |
+| `LOW` | 1 | Stamped but unverified (no test/review evidence) — verify before trusting |
+| `STALE` | 1 | File modified after stamping, or claims expired — re-verify |
+| `UNSTAMPED` | 2 | No metadata — treat as unverified |
+
+## Python API
+
+```python
+import akf
+
+result = akf.check_file("auth.py")
+if result.status == "OK":
+    ...  # skip re-verification
+print(result.summary_line())   # OK trust=0.65 agent=claude-code evidence=test_pass age=1d claims=1
+print(result.to_dict())        # full structured result
+```
+
+## How trust is computed
+
+Verification receipts upgrade a stamp's authority: a bare AI stamp scores LOW no matter its confidence, but `test_pass`/`ci_pass` evidence lifts it to verified-process authority, and `human_review` higher still. Weak signals alone (`lint_clean`, `type_check`) don't clear the default 0.6 threshold.
+
+Staleness is mechanical: if the file's mtime is later than the stamp timestamp, the stamp no longer describes the file — `STALE`.

--- a/skills/stamp.md
+++ b/skills/stamp.md
@@ -1,12 +1,18 @@
 # Skill: Stamp Trust Metadata
 
-Stamp trust metadata onto any AI-generated output using AKF.
+Stamp trust metadata onto any AI-generated output using AKF. A stamp is a note you leave for the next agent: what you did, what you verified, how much to trust it. It costs ~15 tokens and saves the next session thousands in re-verification.
 
 ## When to use
 
 - After generating content, code, or analysis
 - After completing a task with verifiable evidence
 - When committing code changes
+- Before checking existing files, see the companion skill: `check.md` (`akf check <file>`)
+
+## Rules
+
+- Only claim evidence you actually observed. A stamp saying tests passed when they didn't poisons every agent that trusts it.
+- Stamp with the strongest evidence you have: test runs and human review make the stamp trustworthy (`akf check` → OK); bare stamps stay LOW.
 
 ## Python API
 


### PR DESCRIPTION
## What

Repositions AKF's story from "stamp because provenance matters" to **"check before you trust — a stamp costs ~15 tokens, re-verifying costs 15,000."** Same product, same schema; the docs now lead with the read path that pays the stamper back.

### README
- **New hero**: agent-paste install block at the top — paste one block into Claude Code / Cursor / OpenClaw and the agent installs and configures AKF itself
- **"Why agents need this"**: the cross-session flow — stamp with evidence → next agent runs `akf check` → OK skips re-verification, STALE catches unverified edits
- `akf check` woven into Quickstart, For AI Agents, and the CLI reference; MCP tool count 9 → 10
- vs-Alternatives table and EU AI Act compliance moved below the fold (content kept)

### CLAUDE.md
Rewritten as the **read-before-redo protocol**: check before building on a file; stamp only evidence you actually observed (a false "tests passed" stamp poisons every agent that trusts it).

### Skills
- New [`skills/check.md`](skills/check.md) — when to check, how to act on each status
- `skills/stamp.md` reframed: stamps are notes for the next agent, with honesty rules

## Why

Adoption analysis: viral agent tools deliver a selfish, felt benefit in the first session. Stamping alone is a tax whose value accrues to someone else later. `akf check` (#113) closed the loop in code; this PR closes it in the story.

## Testing
- All CLI examples in the docs run against the shipped `akf check` behavior (outputs copied from real runs)
- Markdown renders checked; new files stamped with AKF metadata (dogfooding)