### PR TITLE
feat(init): zero-effort setup — hooks and rules by default

### DIFF
--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -35,47 +35,105 @@ def main(ctx) -> None:
 
 
 @main.command("init")
-@click.option("--git-hooks", is_flag=True, help="Install post-commit hook for akf stamp-commit")
+@click.option("--only", "only", multiple=True,
+              type=click.Choice(["config", "git", "claude", "rules"]),
+              help="Limit setup to specific pieces (repeatable)")
+@click.option("--git-hooks", is_flag=True, hidden=True,
+              help="Deprecated: git hooks are now installed by default")
 @click.option("--agent", help="Default AI agent ID")
 @click.option("--label", "classification", default="internal", help="Default classification")
 @click.option("--path", "target", default=".", type=click.Path(), help="Project root")
-def init_cmd(git_hooks, agent, classification, target) -> None:
-    """Initialize AKF in a project directory."""
+def init_cmd(only, git_hooks, agent, classification, target) -> None:
+    """Wire AKF into a project — config, git hooks, Claude Code hooks, agent rules.
+
+    Default-on: one command sets up everything it can detect, so every
+    commit and every agent-written file carries trust metadata automatically.
+    Idempotent — safe to re-run. Use --only to scope (e.g. --only git).
+    """
+    from . import init_setup
+
     root = Path(target).resolve()
-    akf_dir = root / ".akf"
-    akf_dir.mkdir(exist_ok=True)
+    sections = set(only) if only else {"config", "git", "claude", "rules"}
 
-    config = {
-        "version": "1.0",
-        "classification": classification,
-        "auto_embed": True,
-    }
-    if agent:
-        config["agent"] = agent
+    messages = []
+    if "config" in sections:
+        messages += init_setup.setup_config(root, agent, classification)
+    if "git" in sections:
+        messages += init_setup.setup_git_hooks(root)
+    if "claude" in sections:
+        messages += init_setup.setup_claude(root)
+    if "rules" in sections:
+        messages += init_setup.setup_rules(root)
 
-    config_path = akf_dir / "config.json"
-    config_path.write_text(json.dumps(config, indent=2) + "\n")
-    click.secho(f"Created {config_path}", fg="green")
-
-    if git_hooks:
-        hooks_dir = root / ".git" / "hooks"
-        if not hooks_dir.parent.exists():
-            click.secho("Warning: .git directory not found, skipping hooks", fg="yellow")
-        else:
-            hooks_dir.mkdir(exist_ok=True)
-            hook = hooks_dir / "post-commit"
-            hook.write_text("#!/bin/sh\nakf stamp-commit\n")
-            hook.chmod(0o755)
-            click.secho(f"Installed post-commit hook: {hook}", fg="green")
+    for msg in messages:
+        color = "yellow" if "skipped" in msg else "green"
+        click.secho(f"  {msg}", fg=color)
 
     click.echo()
     click.secho("AKF initialized!", bold=True)
-    click.echo("  Config:  .akf/config.json")
     click.echo()
-    click.echo("Quick start:")
-    click.echo("  akf embed report.docx         # add trust metadata")
-    click.echo("  akf read report.docx           # view trust metadata")
-    click.echo("  akf audit report.docx          # compliance check")
+    click.echo("Using MCP? Register the server:")
+    click.echo(init_setup.MCP_SNIPPET)
+    click.echo()
+    click.echo("The loop:")
+    click.echo("  akf check <file>     # before building on a file")
+    click.echo("  akf stamp <file> --agent <id> --evidence \"tests pass\"")
+
+
+@main.group("hook")
+def hook_group() -> None:
+    """Hook entry points used by akf init (git, Claude Code)."""
+
+
+@hook_group.command("post-commit")
+def hook_post_commit() -> None:
+    """Stamp the HEAD commit with AKF metadata (called by the git hook).
+
+    Never fails: hooks must not break commits.
+    """
+    try:
+        from .git_ops import stamp_commit
+        import subprocess
+
+        subject = subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        agent = None
+        config_path = Path(".akf/config.json")
+        if config_path.exists():
+            try:
+                agent = json.loads(config_path.read_text()).get("agent")
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        stamp_commit(content=subject or "commit", agent=agent)
+    except Exception:
+        pass
+
+
+@hook_group.command("claude")
+def hook_claude() -> None:
+    """Stamp a file written by Claude Code (PostToolUse hook entry point).
+
+    Reads the hook payload from stdin, stamps tool_input.file_path.
+    Always exits 0: a provenance hook must never block the agent.
+    """
+    try:
+        payload = json.load(sys.stdin)
+        filepath = (payload.get("tool_input") or {}).get("file_path")
+        if not filepath or not Path(filepath).is_file():
+            return
+        if filepath.endswith(".akf.json") or "/.git/" in filepath:
+            return
+
+        from .stamp import stamp_file as _stamp_file
+
+        _stamp_file(filepath, agent="claude-code",
+                    claims=[f"Written by Claude Code: {Path(filepath).name}"])
+    except Exception:
+        pass
 
 
 @main.command("read")

--- a/python/akf/init_setup.py
+++ b/python/akf/init_setup.py
@@ -1,0 +1,173 @@
+"""Zero-effort project setup for AKF.
+
+`akf init` wires AKF into everything it can detect in a project, so
+stamping happens by default instead of by discipline:
+
+- ``.akf/config.json``       — project defaults (classification, agent)
+- git post-commit hook       — stamps every commit via ``akf hook post-commit``
+- ``.claude/settings.json``  — Claude Code PostToolUse hook that stamps
+                               every file the agent writes or edits
+- agent rules files          — AKF protocol stanza in CLAUDE.md, AGENTS.md,
+                               .cursorrules, .windsurfrules,
+                               .github/copilot-instructions.md
+
+All setup is idempotent: stanzas live between marker comments and are
+replaced in place; hooks are skipped when already installed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Optional
+
+STANZA_BEGIN = "<!-- akf:protocol:begin -->"
+STANZA_END = "<!-- akf:protocol:end -->"
+
+PROTOCOL_STANZA = f"""{STANZA_BEGIN}
+## AKF trust protocol
+
+Before building on an existing file, check it:
+
+    akf check <file>
+
+OK = fresh stamp with verified evidence — build on it, skip re-verification.
+STALE / LOW / UNSTAMPED = verify before trusting.
+
+After creating or modifying a file, stamp what you verified:
+
+    akf stamp <file> --agent <your-id> --evidence "<what you verified, e.g. 42/42 tests passed>"
+
+Only claim evidence you actually observed.
+{STANZA_END}"""
+
+# Rules files that get the protocol stanza, in priority order. The first
+# group are updated when present; AGENTS.md is created if nothing exists.
+RULES_FILES = [
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".cursorrules",
+    ".windsurfrules",
+    ".github/copilot-instructions.md",
+]
+
+GIT_HOOK_LINE = "akf hook post-commit"
+# Provenance must never make noise or block a commit, even with a broken install.
+GIT_HOOK_INVOCATION = f"{GIT_HOOK_LINE} >/dev/null 2>&1 || true"
+CLAUDE_HOOK_COMMAND = "akf hook claude"
+
+MCP_SNIPPET = json.dumps(
+    {"mcpServers": {"akf": {"command": "python", "args": ["-m", "mcp_server_akf"]}}},
+    indent=2,
+)
+
+
+def setup_config(root: Path, agent: Optional[str], classification: str) -> List[str]:
+    """Write .akf/config.json, preserving existing keys."""
+    akf_dir = root / ".akf"
+    akf_dir.mkdir(exist_ok=True)
+    config_path = akf_dir / "config.json"
+
+    config = {}
+    if config_path.exists():
+        try:
+            config = json.loads(config_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            config = {}
+
+    config.setdefault("version", "1.0")
+    config["classification"] = classification
+    config.setdefault("auto_embed", True)
+    if agent:
+        config["agent"] = agent
+
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+    return [f"config    {config_path.relative_to(root)}"]
+
+
+def setup_git_hooks(root: Path) -> List[str]:
+    """Install a post-commit hook that stamps every commit."""
+    git_dir = root / ".git"
+    if not git_dir.exists():
+        return ["git       skipped (not a git repository)"]
+
+    hooks_dir = git_dir / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+    hook = hooks_dir / "post-commit"
+
+    if hook.exists():
+        existing = hook.read_text()
+        if GIT_HOOK_LINE in existing:
+            return ["git       post-commit hook already installed"]
+        # Append to an existing hook rather than clobbering it.
+        hook.write_text(existing.rstrip("\n") + f"\n{GIT_HOOK_INVOCATION}\n")
+    else:
+        hook.write_text(f"#!/bin/sh\n{GIT_HOOK_INVOCATION}\n")
+    hook.chmod(0o755)
+    return [f"git       post-commit hook -> {GIT_HOOK_LINE}"]
+
+
+def setup_claude(root: Path) -> List[str]:
+    """Add a PostToolUse hook to .claude/settings.json that auto-stamps
+    files written or edited by Claude Code."""
+    claude_dir = root / ".claude"
+    settings_path = claude_dir / "settings.json"
+
+    settings = {}
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return [f"claude    skipped ({settings_path.relative_to(root)} is not valid JSON)"]
+
+    hooks = settings.setdefault("hooks", {})
+    post_tool_use = hooks.setdefault("PostToolUse", [])
+
+    for entry in post_tool_use:
+        for h in entry.get("hooks", []):
+            if CLAUDE_HOOK_COMMAND in h.get("command", ""):
+                return ["claude    PostToolUse hook already installed"]
+
+    post_tool_use.append({
+        "matcher": "Write|Edit",
+        "hooks": [{"type": "command", "command": CLAUDE_HOOK_COMMAND}],
+    })
+
+    claude_dir.mkdir(exist_ok=True)
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+    return [f"claude    PostToolUse auto-stamp hook -> {settings_path.relative_to(root)}"]
+
+
+def _apply_stanza(path: Path) -> str:
+    """Insert or refresh the protocol stanza in a rules file."""
+    text = path.read_text() if path.exists() else ""
+
+    if STANZA_BEGIN in text and STANZA_END in text:
+        before = text.split(STANZA_BEGIN)[0]
+        after = text.split(STANZA_END, 1)[1]
+        updated = before + PROTOCOL_STANZA + after
+        if updated == text:
+            return "unchanged"
+        path.write_text(updated)
+        return "refreshed"
+
+    prefix = text.rstrip("\n") + "\n\n" if text.strip() else ""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(prefix + PROTOCOL_STANZA + "\n")
+    return "created" if not text else "added"
+
+
+def setup_rules(root: Path) -> List[str]:
+    """Add the AKF protocol stanza to agent rules files.
+
+    Updates every rules file that already exists; if none exist, creates
+    AGENTS.md (the cross-tool convention).
+    """
+    messages = []
+    existing = [f for f in RULES_FILES if (root / f).exists()]
+    targets = existing if existing else ["AGENTS.md"]
+
+    for name in targets:
+        action = _apply_stanza(root / name)
+        messages.append(f"rules     {name} ({action})")
+    return messages

--- a/python/tests/test_init_setup.py
+++ b/python/tests/test_init_setup.py
@@ -1,0 +1,139 @@
+"""Tests for zero-effort akf init and hook entry points."""
+
+import json
+import subprocess
+
+import pytest
+from click.testing import CliRunner
+
+from akf.cli import main
+from akf import init_setup
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A bare project directory with a git repo."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    return tmp_path
+
+
+class TestInitDefault:
+    def test_sets_up_everything(self, runner, project):
+        result = runner.invoke(main, ["init", "--path", str(project)])
+        assert result.exit_code == 0
+        assert (project / ".akf" / "config.json").exists()
+        assert (project / ".git" / "hooks" / "post-commit").exists()
+        assert (project / ".claude" / "settings.json").exists()
+        assert (project / "AGENTS.md").exists()
+        assert "mcp_server_akf" in result.output
+
+    def test_idempotent(self, runner, project):
+        runner.invoke(main, ["init", "--path", str(project)])
+        first = {
+            "settings": (project / ".claude" / "settings.json").read_text(),
+            "agents": (project / "AGENTS.md").read_text(),
+            "hook": (project / ".git" / "hooks" / "post-commit").read_text(),
+        }
+        result = runner.invoke(main, ["init", "--path", str(project)])
+        assert result.exit_code == 0
+        assert (project / ".claude" / "settings.json").read_text() == first["settings"]
+        assert (project / "AGENTS.md").read_text() == first["agents"]
+        assert (project / ".git" / "hooks" / "post-commit").read_text() == first["hook"]
+
+    def test_only_scoping(self, runner, project):
+        result = runner.invoke(main, ["init", "--path", str(project), "--only", "git"])
+        assert result.exit_code == 0
+        assert (project / ".git" / "hooks" / "post-commit").exists()
+        assert not (project / ".claude").exists()
+        assert not (project / "AGENTS.md").exists()
+
+    def test_no_git_repo_skips_hooks(self, runner, tmp_path):
+        result = runner.invoke(main, ["init", "--path", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "skipped (not a git repository)" in result.output
+
+
+class TestGitHook:
+    def test_hook_calls_akf_hook_post_commit(self, runner, project):
+        runner.invoke(main, ["init", "--path", str(project), "--only", "git"])
+        hook = (project / ".git" / "hooks" / "post-commit").read_text()
+        assert "akf hook post-commit" in hook
+
+    def test_appends_to_existing_hook(self, runner, project):
+        hooks_dir = project / ".git" / "hooks"
+        hooks_dir.mkdir(exist_ok=True)
+        existing = hooks_dir / "post-commit"
+        existing.write_text("#!/bin/sh\necho existing\n")
+        runner.invoke(main, ["init", "--path", str(project), "--only", "git"])
+        content = existing.read_text()
+        assert "echo existing" in content
+        assert "akf hook post-commit" in content
+
+
+class TestClaudeHookSetup:
+    def test_settings_shape(self, runner, project):
+        runner.invoke(main, ["init", "--path", str(project), "--only", "claude"])
+        settings = json.loads((project / ".claude" / "settings.json").read_text())
+        entries = settings["hooks"]["PostToolUse"]
+        assert entries[0]["matcher"] == "Write|Edit"
+        assert entries[0]["hooks"][0]["command"] == "akf hook claude"
+
+    def test_merges_into_existing_settings(self, runner, project):
+        claude_dir = project / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(json.dumps({"model": "opus"}))
+        runner.invoke(main, ["init", "--path", str(project), "--only", "claude"])
+        settings = json.loads((claude_dir / "settings.json").read_text())
+        assert settings["model"] == "opus"
+        assert "PostToolUse" in settings["hooks"]
+
+
+class TestRulesStanza:
+    def test_updates_existing_rules_files(self, runner, project):
+        (project / "CLAUDE.md").write_text("# My project\n")
+        (project / ".cursorrules").write_text("be terse\n")
+        runner.invoke(main, ["init", "--path", str(project), "--only", "rules"])
+        claude_md = (project / "CLAUDE.md").read_text()
+        assert "# My project" in claude_md
+        assert init_setup.STANZA_BEGIN in claude_md
+        assert "akf check <file>" in claude_md
+        assert init_setup.STANZA_BEGIN in (project / ".cursorrules").read_text()
+        # AGENTS.md is only created when no rules files exist.
+        assert not (project / "AGENTS.md").exists()
+
+    def test_stanza_refresh_replaces_in_place(self, runner, project):
+        (project / "CLAUDE.md").write_text(
+            f"# Top\n\n{init_setup.STANZA_BEGIN}\nold stanza\n{init_setup.STANZA_END}\n\n# Bottom\n"
+        )
+        runner.invoke(main, ["init", "--path", str(project), "--only", "rules"])
+        content = (project / "CLAUDE.md").read_text()
+        assert "old stanza" not in content
+        assert "akf check <file>" in content
+        assert content.startswith("# Top")
+        assert "# Bottom" in content
+        assert content.count(init_setup.STANZA_BEGIN) == 1
+
+
+class TestClaudeHookEntry:
+    def test_stamps_file_from_payload(self, runner, tmp_path):
+        target = tmp_path / "out.md"
+        target.write_text("# Out\n")
+        payload = json.dumps({"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+        result = runner.invoke(main, ["hook", "claude"], input=payload)
+        assert result.exit_code == 0
+        from akf.check import check_file
+        assert check_file(str(target)).status != "UNSTAMPED"
+
+    def test_never_fails_on_garbage(self, runner):
+        result = runner.invoke(main, ["hook", "claude"], input="not json")
+        assert result.exit_code == 0
+
+    def test_skips_missing_file(self, runner):
+        payload = json.dumps({"tool_input": {"file_path": "/nonexistent/x.md"}})
+        result = runner.invoke(main, ["hook", "claude"], input=payload)
+        assert result.exit_code == 0


### PR DESCRIPTION
## What

`akf init` is now the one-command, default-on setup. EXIF won because cameras embedded it by default — this is AKF's equivalent: after `akf init`, stamping happens automatically instead of by discipline.

```console
$ akf init
  config    .akf/config.json
  git       post-commit hook -> akf hook post-commit
  claude    PostToolUse auto-stamp hook -> .claude/settings.json
  rules     AGENTS.md (created)
```

- **git**: post-commit hook stamps every commit into git notes (`refs/notes/akf`), silent and non-blocking even if the local install is broken
- **claude**: `.claude/settings.json` gains a `PostToolUse` (Write|Edit) hook — every file Claude Code writes gets stamped, zero tokens spent
- **rules**: AKF protocol stanza (check before building, stamp what you verified) added to whichever rules files exist — CLAUDE.md, AGENTS.md, .cursorrules, .windsurfrules, copilot-instructions.md — between `akf:protocol` markers, refreshed in place on re-run; creates AGENTS.md when none exist
- **Idempotent**: safe to re-run; merges into existing settings/hooks instead of clobbering
- `--only config|git|claude|rules` to scope; `--git-hooks` kept as hidden no-op

New `akf hook` command group holds the entry points (`post-commit`, `claude`), both guaranteed to exit 0 — a provenance hook must never block a commit or an agent.

## Bug fix

The previous `--git-hooks` flag installed a hook calling `akf stamp-commit` — **a command that never existed**, so the hook failed silently on every commit. It now calls the real entry point.

## Testing

- 13 new tests: default setup, idempotency, `--only` scoping, existing-hook append, settings merge, stanza refresh-in-place, hook entry points (garbage stdin, missing file)
- Full suite: 1927 passed, 2 skipped
- E2E in a fresh temp repo: `akf init` → commit → `git notes --ref=akf show HEAD` returns the stamp; Claude hook payload stamps the target file