### PR TITLE
feat(stamp): memory and skill presets + decay-aware check

### DIFF
--- a/docs/recipes/agent-memory.md
+++ b/docs/recipes/agent-memory.md
@@ -1,0 +1,101 @@
+---
+akf:
+  v: "1.0"
+  claims:
+    - c: "Trust metadata for docs/recipes/agent-memory.md"
+      t: 0.7
+      id: "69083628"
+      src: unspecified
+      tier: 5
+      ver: false
+      ai: true
+      evidence:
+        - type: other
+          detail: examples verified against shipped CLI behavior
+          at: "2026-07-02T17:06:46.584905+00:00"
+  id: "akf-6ba1923dc909"
+  agent: "claude-code"
+  at: "2026-07-02T17:06:46.587959+00:00"
+  label: public
+  inherit: true
+  ext: false
+  hash: "sha256:757b9950b22601f4"
+  sv: "1.1"
+---
+# Recipe: Trust Metadata for Agent Memory
+
+Agents with persistent memory have a known failure mode: **stale or wrong
+memories poison future sessions.** A memory written three months ago about a
+codebase that has since been refactored is worse than no memory at all — the
+agent trusts it and builds on a lie.
+
+AKF's schema already has everything memory trust needs: `confidence`,
+`decay_half_life`, `src`, and per-claim timestamps. This recipe wires them to
+your agent's memory directory.
+
+## The idea
+
+Stamp every memory file with `--preset memory`. The preset sets a **30-day
+trust half-life**: a memory that starts at 0.7 confidence is worth ~0.35
+after a month and ~0.17 after two. `akf check` applies the decay
+automatically — old memories fall below the trust threshold and report `LOW`,
+telling the agent to re-verify before relying on them.
+
+```bash
+# When the agent writes a memory
+akf stamp memory/project-facts.md --preset memory --agent claude-code \
+    --evidence "observed in session 2026-07-02"
+
+# When a later session reads it
+akf check memory/project-facts.md
+# fresh:      OK trust=0.75 agent=claude-code age=2d ...
+# two months: LOW trust=0.17 agent=claude-code age=61d reason=below_threshold
+```
+
+## Stamping a whole memory directory
+
+```bash
+for f in memory/*.md; do
+  akf stamp "$f" --preset memory --agent claude-code
+done
+```
+
+## Rules stanza for your agent
+
+Add to your CLAUDE.md / AGENTS.md:
+
+```markdown
+## Memory trust
+- After writing a memory file: `akf stamp <file> --preset memory --agent <your-id>`
+- Before relying on a memory: `akf check <file>` — LOW or STALE means the
+  memory is old or was edited without re-verification; confirm it against
+  the current state of the world before using it.
+```
+
+## Choosing a half-life
+
+The preset default is 30 days. For a different shelf life, stamp from Python
+with an explicit `decay_half_life`:
+
+```python
+import akf
+
+# Volatile fact: which branch is deployed (1-day half-life)
+akf.stamp_file("memory/deploy-state.md", agent="claude-code",
+               kind="memory", decay_half_life=1,
+               claims=["main is deployed to prod"])
+```
+
+| Memory type | Suggested half-life |
+|-------------|--------------------|
+| Deploy/runtime state | 1 day |
+| In-progress work notes | 7 days |
+| Project facts, conventions | 30 days (preset default) |
+| User preferences | 365 days |
+
+## Why this beats timestamp-checking
+
+A timestamp tells an agent *when* a memory was written; it doesn't say *how
+much to discount it*. Decay converts age into a trust score on the same 0–1
+scale as everything else, so one threshold (`akf check`) gates memories, code
+stamps, and handoffs uniformly.

--- a/docs/recipes/skill-provenance.md
+++ b/docs/recipes/skill-provenance.md
@@ -1,0 +1,94 @@
+---
+akf:
+  v: "1.0"
+  claims:
+    - c: "Trust metadata for docs/recipes/skill-provenance.md"
+      t: 0.7
+      id: a21eb0c4
+      src: unspecified
+      tier: 5
+      ver: false
+      ai: true
+      evidence:
+        - type: other
+          detail: examples verified against shipped CLI behavior
+          at: "2026-07-02T17:06:46.734585+00:00"
+  id: "akf-8f690dcfa95f"
+  agent: "claude-code"
+  at: "2026-07-02T17:06:46.734803+00:00"
+  label: public
+  inherit: true
+  ext: false
+  hash: "sha256:c09b80e6b731a097"
+  sv: "1.1"
+---
+# Recipe: Skill Supply-Chain Provenance
+
+Agents install skills and plugins from marketplaces — often automatically,
+often without review. The skill ecosystem has already had its first malware
+wave. A skill file is executable *instruction*, and today nothing tells an
+agent (or its human) who published it, when, or whether anyone verified it.
+
+AKF stamps embed in Markdown natively (YAML frontmatter), so a skill file can
+carry its own provenance.
+
+## Publishing a skill
+
+Stamp before you publish:
+
+```bash
+akf stamp skills/my-skill.md --preset skill \
+    --agent "acme-tools" \
+    --claim "Skill published by Acme Tools: converts CSV to trust reports" \
+    --evidence "reviewed by @maintainer"
+```
+
+The `skill` preset sets: `public` classification, 365-day trust half-life,
+and authority tier 3 (unverified third party). Human review evidence raises
+effective trust; a signed stamp raises it further:
+
+```bash
+akf keygen                       # once
+akf sign skills/my-skill.md      # Ed25519 signature travels in the stamp
+```
+
+## Installing a skill
+
+Check before your agent loads it:
+
+```bash
+akf check skills/downloaded-skill.md
+# OK trust=0.78 agent=acme-tools evidence=human_review age=12d
+#   → published, reviewed, unmodified since stamping
+
+# UNSTAMPED reason=no_metadata
+#   → no provenance at all; read it yourself before letting an agent load it
+
+# STALE reason=modified_after_stamp
+#   → the file changed after the publisher stamped it. Diff before trusting.
+```
+
+`STALE` is the supply-chain signal: it means the skill on disk is not the
+skill that was stamped — whether by a legitimate update or a tampered
+download.
+
+## Rules stanza for your agent
+
+```markdown
+## Skill trust
+- Never load a skill file without `akf check` first.
+- UNSTAMPED or STALE skills require human review before use.
+- When you author or modify a skill: `akf stamp <file> --preset skill --agent <your-id>`.
+```
+
+## Verifying a whole skills directory
+
+```bash
+akf scan skills/ --recursive     # trust report for every file
+akf certify skills/ --min-trust 0.6
+```
+
+## A worked example
+
+This repository dogfoods the recipe: [`skills/openclaw-akf/SKILL.md`](../../skills/openclaw-akf/SKILL.md)
+carries an AKF stamp in its frontmatter. Run `akf check` on it.

--- a/python/akf/check.py
+++ b/python/akf/check.py
@@ -109,11 +109,12 @@ def _evidence_types(unit: AKF) -> List[str]:
     return types
 
 
-def _claim_score(claim: Claim) -> float:
-    """Effective trust with evidence-aware authority.
+def _claim_score(claim: Claim, age_days: float = 0) -> float:
+    """Effective trust with evidence-aware authority and temporal decay.
 
     Verification receipts (tests, type checks, human review) floor the
-    authority tier — see _EVIDENCE_TIER_FLOOR.
+    authority tier — see _EVIDENCE_TIER_FLOOR. Stamp age drives decay for
+    claims with a decay_half_life (e.g. memory stamps).
     """
     floors = [
         _EVIDENCE_TIER_FLOOR[ev.type]
@@ -125,7 +126,7 @@ def _claim_score(claim: Claim) -> float:
         floored = min(min(floors), tier)
         if floored != tier:
             claim = claim.model_copy(update={"authority_tier": floored})
-    return effective_trust(claim).score
+    return effective_trust(claim, age_days=age_days).score
 
 
 def check_file(filepath: str, threshold: float = 0.6) -> CheckResult:
@@ -155,13 +156,13 @@ def check_file(filepath: str, threshold: float = 0.6) -> CheckResult:
             threshold=threshold, reason="no_metadata",
         )
 
-    scores = [_claim_score(claim) for claim in unit.claims]
-    overall = round(min(scores), 4) if scores else 0.0
-
     stamped_at = _parse_ts(unit.created) if unit.created else None
     age_days: Optional[int] = None
     if stamped_at is not None:
         age_days = max(0, (datetime.now(timezone.utc) - stamped_at).days)
+
+    scores = [_claim_score(claim, age_days=age_days or 0) for claim in unit.claims]
+    overall = round(min(scores), 4) if scores else 0.0
 
     base = dict(
         file=filepath,

--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -1082,8 +1082,10 @@ def kb_prune_cmd(directory, max_age, min_trust) -> None:
 @click.option("--claim", "claims", multiple=True, help="Claim text (repeatable)")
 @click.option("--model", default=None, help="Model identifier (e.g. gpt-4o)")
 @click.option("--label", default=None, help="Classification label")
+@click.option("--preset", type=click.Choice(["memory", "skill"]), default=None,
+              help="Context preset: memory (30-day trust decay) or skill (public, supply-chain trust)")
 @click.option("--format", "fmt", default="auto", help="Output format: auto, embed, sidecar")
-def stamp_cmd(file, agent, evidence, confidence, claims, model, label, fmt):
+def stamp_cmd(file, agent, evidence, confidence, claims, model, label, preset, fmt):
     """Add AKF trust metadata to any file.
 
     Stamps the file with trust scores, provenance, and classification.
@@ -1094,10 +1096,20 @@ def stamp_cmd(file, agent, evidence, confidence, claims, model, label, fmt):
       akf stamp report.md --agent claude-code --evidence "tests pass"
 
       akf stamp output.pdf --claim "Revenue $4.2B" --confidence 0.95 --model gpt-4o
+
+      akf stamp memory/facts.md --preset memory --agent claude-code
     """
     from .stamp import stamp_file as _stamp_file
 
-    classification = label or "internal"
+    preset_label = None
+    preset_claim_kwargs = {}
+    if preset:
+        from .presets import get_stamp_preset
+        p = get_stamp_preset(preset)
+        preset_label = p.get("classification")
+        preset_claim_kwargs = dict(p.get("claim_kwargs", {}))
+
+    classification = label or preset_label or "internal"
     trust_score = confidence if confidence is not None else 0.7
     evidence_list = list(evidence) if evidence else None
     claim_list = list(claims) if claims else None
@@ -1116,6 +1128,7 @@ def stamp_cmd(file, agent, evidence, confidence, claims, model, label, fmt):
         trust_score=trust_score,
         classification=classification,
         evidence=evidence_list,
+        **preset_claim_kwargs,
     )
 
     claims_count = len(unit.claims)

--- a/python/akf/formats/markdown.py
+++ b/python/akf/formats/markdown.py
@@ -359,12 +359,32 @@ def _yaml_scalar(val: Any) -> str:
     return s
 
 
-def _build_frontmatter(akf_yaml: str, other_fields: Dict[str, str]) -> str:
-    """Build a complete frontmatter block with AKF YAML and other preserved fields."""
+def _strip_akf_from_frontmatter(block: str) -> str:
+    """Remove the akf:/_akf: entries (with their nested lines) from a raw
+    frontmatter block, preserving everything else verbatim.
+
+    Non-AKF frontmatter must survive stamping byte-for-byte — nested
+    structures (tags lists, tool metadata) can't round-trip through a
+    scalar-only parser.
+    """
+    kept: List[str] = []
+    skipping = False
+    for line in block.splitlines():
+        is_top_level = bool(line.strip()) and line[0] not in (" ", "\t")
+        if is_top_level:
+            key = line.split(":", 1)[0].strip()
+            skipping = key in ("akf", "_akf")
+        if not skipping:
+            kept.append(line)
+    return "\n".join(kept)
+
+
+def _build_frontmatter(akf_yaml: str, preserved: str = "") -> str:
+    """Build a complete frontmatter block: preserved fields verbatim, then AKF YAML."""
     lines = ["---"]
-    for key, val in other_fields.items():
-        if key not in ("akf", "_akf"):
-            lines.append("{}: {}".format(key, val))
+    preserved = preserved.strip("\n")
+    if preserved.strip():
+        lines.append(preserved)
     lines.append(akf_yaml)
     lines.append("---")
     return "\n".join(lines) + "\n"
@@ -397,15 +417,16 @@ class MarkdownHandler(AKFFormatHandler):
         fm_block = _parse_frontmatter_raw(content)
 
         if fm_block is not None:
-            # File already has frontmatter — preserve non-AKF keys, replace AKF
-            other_fields = _parse_frontmatter_simple(fm_block)
+            # File already has frontmatter — preserve non-AKF content verbatim,
+            # replace only the akf:/_akf: entries
+            preserved = _strip_akf_from_frontmatter(fm_block)
             m = _FRONTMATTER_RE.match(content)
             assert m is not None
             body = content[m.end():]
-            new_content = _build_frontmatter(akf_yaml, other_fields) + body
+            new_content = _build_frontmatter(akf_yaml, preserved) + body
         else:
             # No frontmatter — add one
-            new_content = _build_frontmatter(akf_yaml, {}) + content
+            new_content = _build_frontmatter(akf_yaml) + content
 
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(new_content)

--- a/python/akf/presets.py
+++ b/python/akf/presets.py
@@ -125,6 +125,36 @@ TEMPLATES: dict[str, Template] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Stamp presets — defaults for `akf stamp --preset <name>`
+# ---------------------------------------------------------------------------
+
+STAMP_PRESETS: dict[str, dict[str, Any]] = {
+    # Agent memory entries: trust decays with a 30-day half-life so stale
+    # memories stop being trusted automatically instead of poisoning
+    # future sessions.
+    "memory": {
+        "classification": "internal",
+        "claim_kwargs": {"kind": "memory", "decay_half_life": 30},
+    },
+    # Skill / plugin files: public artifacts whose provenance is
+    # supply-chain trust. Long half-life; tier 3 until verified.
+    "skill": {
+        "classification": "public",
+        "claim_kwargs": {"kind": "skill", "decay_half_life": 365, "authority_tier": 3},
+    },
+}
+
+
+def get_stamp_preset(name: str) -> dict[str, Any]:
+    """Get a stamp preset by name. Raises KeyError if not found."""
+    if name not in STAMP_PRESETS:
+        raise KeyError(
+            f"Unknown stamp preset: {name}. Available: {', '.join(STAMP_PRESETS.keys())}"
+        )
+    return STAMP_PRESETS[name]
+
+
 def register(name: str, template: Template) -> None:
     """Register a custom template."""
     TEMPLATES[name] = template

--- a/python/akf/stamp.py
+++ b/python/akf/stamp.py
@@ -207,6 +207,7 @@ def stamp_file(
             claim_kwargs["evidence"] = evidence_objects
         if model:
             claim_kwargs["origin"] = Origin(type="ai", model=model)
+        claim_kwargs.update(kwargs)  # extra Claim fields (kind, decay_half_life, ...)
         claim_list.append(
             Claim(content=text, confidence=trust_score, **claim_kwargs)
         )

--- a/python/tests/test_formats/test_markdown.py
+++ b/python/tests/test_formats/test_markdown.py
@@ -319,3 +319,46 @@ class TestModuleConvenience:
         result = md_extract(filepath)
         assert result is not None
         assert result["akf"] == "1.0"
+
+
+# --------------------------------------------------------------------------
+# Nested frontmatter preservation (regression: stamping destroyed nested YAML)
+# --------------------------------------------------------------------------
+
+
+class TestNestedFrontmatterPreservation:
+    NESTED = (
+        "---\n"
+        "name: my-skill\n"
+        "metadata:\n"
+        "  openclaw:\n"
+        "    emoji: \"X\"\n"
+        "    install:\n"
+        "      - id: pip\n"
+        "        package: akf\n"
+        "tags:\n"
+        "  - trust\n"
+        "  - provenance\n"
+        "---\n"
+        "\n# Body\n"
+    )
+
+    def test_embed_preserves_nested_yaml(self, handler: MarkdownHandler, tmp_md) -> None:
+        path = tmp_md(self.NESTED)
+        handler.embed(path, {"v": "1.0", "claims": [{"c": "test", "t": 0.9}]})
+        content = open(path).read()
+        assert "openclaw:" in content
+        assert "- id: pip" in content
+        assert "- trust" in content
+        assert "akf:" in content
+        assert "# Body" in content
+
+    def test_restamp_replaces_akf_only(self, handler: MarkdownHandler, tmp_md) -> None:
+        path = tmp_md(self.NESTED)
+        handler.embed(path, {"v": "1.0", "claims": [{"c": "first", "t": 0.9}]})
+        handler.embed(path, {"v": "1.0", "claims": [{"c": "second", "t": 0.8}]})
+        content = open(path).read()
+        assert content.count("openclaw:") == 1
+        assert "second" in content and "first" not in content
+        meta = handler.extract(path)
+        assert meta["claims"][0].get("c", meta["claims"][0].get("content")) == "second"

--- a/python/tests/test_stamp_presets.py
+++ b/python/tests/test_stamp_presets.py
@@ -1,0 +1,96 @@
+"""Tests for akf stamp --preset (memory, skill) and decay-aware check."""
+
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from click.testing import CliRunner
+
+from akf.check import check_file
+from akf.cli import main
+from akf.presets import STAMP_PRESETS, get_stamp_preset
+from akf import universal
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestPresetDefinitions:
+    def test_memory_preset(self):
+        p = get_stamp_preset("memory")
+        assert p["claim_kwargs"]["decay_half_life"] == 30
+        assert p["claim_kwargs"]["kind"] == "memory"
+        assert p["classification"] == "internal"
+
+    def test_skill_preset(self):
+        p = get_stamp_preset("skill")
+        assert p["classification"] == "public"
+        assert p["claim_kwargs"]["decay_half_life"] == 365
+        assert p["claim_kwargs"]["authority_tier"] == 3
+
+    def test_unknown_preset_raises(self):
+        with pytest.raises(KeyError):
+            get_stamp_preset("nope")
+
+
+class TestStampPresetCli:
+    def test_memory_preset_sets_decay_and_kind(self, runner, tmp_path):
+        path = tmp_path / "facts.md"
+        path.write_text("# Facts\n")
+        result = runner.invoke(main, ["stamp", str(path), "--preset", "memory",
+                                      "--agent", "claude-code"])
+        assert result.exit_code == 0
+        meta = universal.extract(str(path))
+        claim = meta["claims"][0]
+        assert claim.get("decay") == 30 or claim.get("decay_half_life") == 30
+        assert claim.get("kind") == "memory"
+        assert meta.get("classification", meta.get("label")) == "internal"
+
+    def test_skill_preset_sets_public_and_tier(self, runner, tmp_path):
+        path = tmp_path / "skill.md"
+        path.write_text("# Skill\n")
+        result = runner.invoke(main, ["stamp", str(path), "--preset", "skill",
+                                      "--agent", "acme"])
+        assert result.exit_code == 0
+        meta = universal.extract(str(path))
+        assert meta.get("classification", meta.get("label")) == "public"
+        assert meta["claims"][0].get("tier", meta["claims"][0].get("authority_tier")) == 3
+
+    def test_explicit_label_beats_preset(self, runner, tmp_path):
+        path = tmp_path / "skill.md"
+        path.write_text("# Skill\n")
+        runner.invoke(main, ["stamp", str(path), "--preset", "skill",
+                             "--label", "confidential"])
+        meta = universal.extract(str(path))
+        assert meta.get("classification", meta.get("label")) == "confidential"
+
+
+class TestMemoryDecayInCheck:
+    def _backdate_stamp(self, path, days):
+        """Rewrite the stamp's created timestamp to `days` ago and keep the
+        file mtime older than that so the stamp isn't STALE."""
+        meta = universal.extract(str(path))
+        old = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+        meta["at"] = old
+        meta.pop("created", None)
+        universal.embed(str(path), metadata=meta)
+        past = time.time() - days * 86400
+        os.utime(str(path), (past, past))
+
+    def test_fresh_memory_ok_decayed_memory_low(self, runner, tmp_path):
+        path = tmp_path / "mem.md"
+        path.write_text("# Mem\n")
+        runner.invoke(main, ["stamp", str(path), "--preset", "memory",
+                             "--agent", "claude-code", "--confidence", "0.9",
+                             "--evidence", "tests pass"])
+        fresh = check_file(str(path))
+        assert fresh.status == "OK"
+
+        self._backdate_stamp(path, days=90)
+        decayed = check_file(str(path))
+        assert decayed.status == "LOW"
+        assert decayed.trust < fresh.trust / 2  # three half-lives

--- a/skills/openclaw-akf/SKILL.md
+++ b/skills/openclaw-akf/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: akf
+description: Agent Knowledge Format — stamp trust metadata into every file AI touches. Trust scores, provenance, and compliance that embed natively into DOCX, PDF, images, and code.
+homepage: https://akf.dev
+metadata:
+  openclaw:
+    emoji: "🔐"
+    requires:
+      bins: ["akf"]
+    install:
+      - id: pip
+        kind: pip
+        package: akf
+        bins: ["akf"]
+        label: "Install AKF CLI (pip)"
+      - id: npm
+        kind: npm
+        package: akf-format
+        bins: []
+        label: "Install AKF TypeScript SDK (npm)"
+akf:
+  v: "1.0"
+  claims:
+    - c: OpenClaw skill for AKF published by the AKF project
+      t: 0.7
+      id: d3ba7fea
+      src: unspecified
+      tier: 3
+      ver: false
+      ai: true
+      decay: 365
+      kind: skill
+      evidence:
+        - type: human_review
+          detail: "reviewed by @HMAKT99"
+          at: "2026-07-02T17:04:35.591774+00:00"
+  id: "akf-838b9351c281"
+  agent: "claude-code"
+  at: "2026-07-02T17:04:35.593320+00:00"
+  label: public
+  inherit: true
+  ext: false
+  hash: "sha256:6746278d98aacbc6"
+  sv: "1.1"
+---
+
+# AKF — Agent Knowledge Format
+
+AKF is the trust metadata standard for AI-generated content. Think EXIF for AI. Every file your agent creates or modifies should carry trust metadata — who made it, how confident they are, what evidence backs it, and whether a human reviewed it.
+
+## Why Use AKF
+
+- **Trust scores**: 0–1 confidence rating per claim
+- **Source provenance**: 5-tier system from peer-reviewed to unverified
+- **Compliance**: EU AI Act, HIPAA, SOX, NIST audit support
+- **Native embedding**: Metadata lives inside the file (DOCX, PDF, images, code)
+- **Security detections**: 10 detection classes for AI content risks
+
+## Quick Start
+
+Before building on an existing file — check it (one line, ~20 tokens):
+
+```bash
+akf check <file>
+# OK        → fresh stamp with verified evidence; skip re-verification
+# STALE     → modified after stamping; re-verify before trusting
+# LOW       → stamped but unverified; verify before trusting
+# UNSTAMPED → no metadata; treat as unverified
+```
+
+After creating or modifying any file:
+
+```bash
+akf stamp <file> --agent openclaw --evidence "generated from user request"
+```
+
+Deeper inspection when needed:
+
+```bash
+akf read <file>     # Check trust metadata
+akf inspect <file>  # Pretty-print trust scores
+akf trust <file>    # Compute effective trust
+```
+
+## Core Commands
+
+### Stamp — Add trust metadata
+```bash
+akf stamp report.docx --agent openclaw --evidence "quarterly data from ERP"
+akf stamp analysis.pdf --agent openclaw --label confidential
+akf stamp output.py --agent openclaw --evidence "tests pass, code reviewed"
+```
+
+### Read & Inspect — Check metadata
+```bash
+akf read report.docx          # Quick metadata view
+akf inspect report.docx       # Detailed trust breakdown
+akf trust report.docx         # Effective trust score with decision
+```
+
+### Embed & Extract — Native format support
+```bash
+akf embed report.docx         # Embed metadata into DOCX custom properties
+akf extract report.docx       # Extract embedded metadata
+```
+
+### Security — Scan and audit
+```bash
+akf scan ./output-dir/        # Scan directory for trust gaps
+akf audit report.pdf           # Compliance audit (EU AI Act, SOX, NIST)
+```
+
+## Classification Labels
+
+Use `--label` to classify output sensitivity:
+
+| Label | When to Use |
+|-------|-------------|
+| `public` | README, docs, open-source examples |
+| `internal` | Default. General work output |
+| `confidential` | Finance, legal, medical, HR content |
+| `restricted` | Credentials, secrets, PII |
+
+## Trust Score Interpretation
+
+| Score | Decision | Meaning |
+|-------|----------|---------|
+| 0.80–1.00 | ACCEPT | High confidence, well-evidenced |
+| 0.50–0.79 | REVIEW | Moderate confidence, needs verification |
+| 0.00–0.49 | REJECT | Low confidence, unreliable |
+
+## Best Practices for OpenClaw Agents
+
+1. **Always stamp outputs**: Every file the agent creates should carry metadata
+2. **Check before using**: Run `akf read` on files before processing them
+3. **Audit periodically**: Use `akf scan` on output directories to find trust gaps
+4. **Use appropriate labels**: Classify sensitive content correctly
+5. **Include evidence**: The `--evidence` flag makes trust scores meaningful
+6. **Chain provenance**: When building on other files, the trust chain is preserved
+
+## Integration with Memory
+
+Stale memories poison future sessions. Stamp memory files with the `memory`
+preset — trust decays with a 30-day half-life, so old memories automatically
+fall below the threshold and `akf check` reports LOW:
+
+```bash
+akf stamp memory/facts.md --preset memory --agent openclaw
+akf check memory/facts.md   # LOW after ~a month → re-verify before relying on it
+```
+
+- Stamp files before adding to memory
+- `akf check` when retrieving from memory
+- Weight memory results by trust, not just relevance
+
+## Skill Supply-Chain Trust
+
+Never load a downloaded skill without checking it first:
+
+```bash
+akf check downloaded-skill.md
+# STALE = the file changed after the publisher stamped it — diff before trusting
+```
+
+This file carries its own AKF stamp in the frontmatter — run `akf check` on it.
+
+## Links
+
+- Website: https://akf.dev
+- GitHub: https://github.com/HMAKT99/AKF
+- npm: `npm install akf-format`
+- PyPI: `pip install akf`
+- Spec: https://github.com/HMAKT99/AKF/blob/main/spec/akf-v1.1.schema.json


### PR DESCRIPTION
## What

Points AKF's existing schema fields (`decay_half_life`, `kind`, tiers) at two agent-native surfaces: **persistent memory** and the **skill supply chain**.

### `akf stamp --preset memory`
30-day trust half-life. Stale memories are a known agent failure mode — a three-month-old memory about a refactored codebase is worse than none. With the preset, `akf check` on a memory file automatically reports `LOW` once trust has decayed below threshold, telling the agent to re-verify instead of trusting a lie.

```console
$ akf stamp memory/facts.md --preset memory --agent claude-code
$ akf check memory/facts.md      # fresh: OK trust=0.75 ... age=2d
$ akf check memory/facts.md      # 2 months later: LOW trust=0.17 age=61d
```

### `akf stamp --preset skill`
Public classification, 365-day half-life, tier 3 — provenance for skill/plugin files agents install from marketplaces. `STALE` becomes the supply-chain signal: the file on disk is not the file the publisher stamped.

### Decay-aware `akf check`
`check` now feeds stamp age into the existing decay math — previously `decay_half_life` was stored but never applied on the read path.

### Recipes + worked example
- [`docs/recipes/agent-memory.md`](docs/recipes/agent-memory.md) — half-life table per memory type, rules stanza
- [`docs/recipes/skill-provenance.md`](docs/recipes/skill-provenance.md) — publish/install flows
- `skills/openclaw-akf/SKILL.md` updated with check-first + memory + supply-chain guidance, and now carries its own AKF stamp (dogfooding)

## Bug fixes found while dogfooding

1. **Markdown frontmatter embedding destroyed nested YAML.** Stamping a file whose frontmatter had nested structures (OpenClaw `metadata:`, Jekyll/Obsidian `tags:` lists) silently deleted them — the handler round-tripped frontmatter through a scalar-only parser. Non-AKF frontmatter is now preserved verbatim. Regression tests added.
2. **`stamp_file` dropped extra Claim kwargs** (`kind`, `decay_half_life`) — they never reached the claim.

## Testing
- 7 new preset tests + 2 nested-frontmatter regression tests
- Full suite: 1923 passed, 2 skipped
- Live verification: stamped the OpenClaw skill, confirmed its install metadata survives and `akf check` returns OK with human_review evidence