### PR TITLE
feat(scan): trust badge, self-documenting sidecars, PR comment polish

### DIFF
--- a/.github/akf-badge.json
+++ b/.github/akf-badge.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "AKF",
+  "message": "14% stamped \u00b7 trust 0.76",
+  "color": "brightgreen"
+}

--- a/.github/workflows/akf-badge.yml
+++ b/.github/workflows/akf-badge.yml
@@ -1,0 +1,35 @@
+name: AKF Badge
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  badge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install AKF from this repo
+        run: pip install ./python
+
+      - name: Regenerate trust badge
+        run: akf scan . --badge .github/akf-badge.json --max-files 3000
+
+      - name: Commit badge if changed
+        run: |
+          if ! git diff --quiet .github/akf-badge.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add .github/akf-badge.json
+            git commit -m "chore(badge): refresh AKF trust badge"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ _akf: '{"v":"1.0","claims":[{"c":"Trust metadata for README.md","t":0.7,"id":"19
   <a href="https://www.npmjs.com/package/akf-format"><img src="https://img.shields.io/npm/v/akf-format?style=flat-square&label=npm" /></a>
   <a href="https://www.npmjs.com/package/akf-format"><img src="https://img.shields.io/npm/dw/akf-format?style=flat-square&label=npm%20downloads" /></a>
   <a href="https://github.com/HMAKT99/AKF/actions"><img src="https://img.shields.io/github/actions/workflow/status/HMAKT99/AKF/ci.yml?style=flat-square&label=CI" /></a>
+  <a href="https://github.com/HMAKT99/AKF/blob/main/.github/akf-badge.json"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FHMAKT99%2FAKF%2Fmain%2F.github%2Fakf-badge.json&style=flat-square" alt="AKF trust" /></a>
   <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" />
   <a href="https://akf.dev"><img src="https://img.shields.io/badge/docs-akf.dev-blue?style=flat-square" /></a>
   <a href="https://stackshare.io/akf-the-ai-native-file-format"><img src="https://img.shields.io/badge/stackshare-listed-blue?style=flat-square" /></a>
@@ -428,6 +429,7 @@ akf embed report.docx --classification confidential \
 akf extract report.docx
 akf scan report.docx
 akf scan ./docs/ --recursive
+akf scan . --badge badge.json     # shields.io endpoint: "14% stamped · trust 0.76"
 
 # ── Auto-stamping ──
 akf install                                   # Install background watcher

--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -612,6 +612,34 @@ def _export_report(file_or_dir, output, open_report, command_name):
         webbrowser.open("file://" + os.path.abspath(output))
 
 
+def _build_badge(reports) -> dict:
+    """Build a shields.io endpoint JSON payload from scan reports.
+
+    Message: "<stamped>% stamped · trust <avg>". Color tracks avg trust
+    of stamped files (green >= 0.7, yellow >= 0.4, red below).
+    """
+    total = len(reports)
+    enriched = [r for r in reports if r.enriched]
+    if not total or not enriched:
+        return {
+            "schemaVersion": 1,
+            "label": "AKF",
+            "message": "no trust metadata",
+            "color": "lightgrey",
+        }
+
+    pct = round(100 * len(enriched) / total)
+    scores = [r.overall_trust for r in enriched if r.overall_trust is not None]
+    avg = sum(scores) / len(scores) if scores else 0.0
+    color = "brightgreen" if avg >= 0.7 else "yellow" if avg >= 0.4 else "red"
+    return {
+        "schemaVersion": 1,
+        "label": "AKF",
+        "message": f"{pct}% stamped · trust {avg:.2f}",
+        "color": color,
+    }
+
+
 def _trust_bar(count, total, width=20):
     """Render an ASCII trust bar."""
     if total <= 0:
@@ -631,11 +659,27 @@ def _trust_bar(count, total, width=20):
 @click.option("--max-files", "-n", default=10000, type=int, help="Maximum files to scan (default: 10000)")
 @click.option("--output", "-o", type=click.Path(), help="Export report (.html, .json, .csv, .md, .pdf)")
 @click.option("--open", "open_report", is_flag=True, help="Open report in browser after export")
-def scan_cmd(file_or_dir, recursive, max_files, output, open_report) -> None:
+@click.option("--badge", "badge_path", type=click.Path(),
+              help="Write a shields.io endpoint JSON badge (stamped %, avg trust); use - for stdout")
+def scan_cmd(file_or_dir, recursive, max_files, output, open_report, badge_path) -> None:
     """Security scan any file or directory for AKF metadata."""
     from . import universal as akf_u
     from pathlib import Path
     from collections import Counter
+
+    if badge_path:
+        reports = akf_u.scan_directory(str(file_or_dir), recursive=recursive, max_files=max_files)
+        badge = _build_badge(reports)
+        payload = json.dumps(badge, indent=2) + "\n"
+        if badge_path == "-":
+            click.echo(payload, nl=False)
+        else:
+            with open(badge_path, "w") as f:
+                f.write(payload)
+            click.secho(f"Badge written to {badge_path}", fg="green")
+            click.echo("Embed it with shields.io:")
+            click.echo("  https://img.shields.io/endpoint?url=<public URL of this JSON>")
+        return
 
     if output:
         _export_report(file_or_dir, output, open_report, "scan")
@@ -1949,19 +1993,42 @@ def _print_certify_summary(report) -> None:
         click.secho("  Certification incomplete.", fg="red", bold=True)
 
 
-def _print_certify_markdown(report) -> None:
-    """Print a Markdown table of certification results."""
-    click.echo("| File | Status | Trust | Issues |")
-    click.echo("|------|--------|-------|--------|")
-    for r in report.results:
-        status = "PASS" if r.certified else "FAIL"
+def _print_certify_markdown(report, max_rows: int = 50) -> None:
+    """Print a Markdown certification report (rendered in PR comments)."""
+    headline_icon = "✅" if report.all_certified else "❌"
+    parts = [f"**{headline_icon} {report.certified_count}/{report.total_files} files certified**"]
+    if report.avg_trust:
+        parts.append(f"average trust **{report.avg_trust:.2f}**")
+    if report.failed_count:
+        parts.append(f"{report.failed_count} failed")
+    click.echo(" · ".join(parts))
+    click.echo()
+
+    click.echo("| | File | Trust | Evidence | Issues |")
+    click.echo("|---|------|-------|----------|--------|")
+    # Failures first — that's what a reviewer needs to see.
+    ordered = sorted(report.results, key=lambda r: (r.certified, r.filepath))
+    for r in ordered[:max_rows]:
+        status = "✅" if r.certified else "❌"
+        ev_types = []
+        for e in r.evidence or []:
+            ev_type = getattr(e, "type", None) or "other"
+            if ev_type not in ev_types:
+                ev_types.append(ev_type)
+        evidence_str = ", ".join(f"`{t}`" for t in ev_types) if ev_types else "—"
         issues = []
         if r.error:
             issues.append(r.error)
         issues.extend(d.detection_class for d in r.detections)
         issues.extend(r.compliance_issues)
-        issues_str = ", ".join(issues) if issues else "-"
-        click.echo(f"| {r.filepath} | {status} | {r.trust_score:.2f} | {issues_str} |")
+        issues_str = ", ".join(issues) if issues else "—"
+        click.echo(f"| {status} | `{r.filepath}` | {r.trust_score:.2f} | {evidence_str} | {issues_str} |")
+
+    if len(ordered) > max_rows:
+        click.echo()
+        click.echo(f"<sub>…and {len(ordered) - max_rows} more files "
+                   f"({report.certified_count} certified in total).</sub>")
+
     click.echo()
     click.echo(f"**Total:** {report.total_files} | "
                f"**Certified:** {report.certified_count} | "

--- a/python/akf/sidecar.py
+++ b/python/akf/sidecar.py
@@ -79,6 +79,9 @@ def create(filepath: str, metadata: Dict[str, Any]) -> str:
 
     sidecar_data: Dict[str, Any] = {
         "akf": "1.0",
+        # Self-documenting: anyone who finds a .akf.json in a repo can
+        # follow this to learn what the format is.
+        "spec": "https://akf.dev",
         "mode": "sidecar",
         "target_file": os.path.basename(filepath),
         "generated_at": now,
@@ -86,7 +89,7 @@ def create(filepath: str, metadata: Dict[str, Any]) -> str:
 
     # Merge user metadata, but preserve our envelope fields
     for key, value in metadata.items():
-        if key not in ("akf", "mode", "target_file", "generated_at"):
+        if key not in ("akf", "spec", "mode", "target_file", "generated_at"):
             sidecar_data[key] = value
 
     # Always set integrity_hash from the actual file

--- a/python/tests/test_badge.py
+++ b/python/tests/test_badge.py
@@ -1,0 +1,72 @@
+"""Tests for akf scan --badge and self-documenting sidecars."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from akf.cli import main, _build_badge
+from akf.formats.base import ScanReport
+from akf.stamp import stamp_file
+from akf import sidecar
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestBuildBadge:
+    def test_empty_scan(self):
+        badge = _build_badge([])
+        assert badge["schemaVersion"] == 1
+        assert badge["color"] == "lightgrey"
+
+    def test_no_enriched_files(self):
+        reports = [ScanReport(enriched=False) for _ in range(3)]
+        assert _build_badge(reports)["message"] == "no trust metadata"
+
+    def test_stamped_percentage_and_trust(self):
+        reports = [
+            ScanReport(enriched=True, overall_trust=0.9),
+            ScanReport(enriched=True, overall_trust=0.7),
+            ScanReport(enriched=False),
+            ScanReport(enriched=False),
+        ]
+        badge = _build_badge(reports)
+        assert badge["message"] == "50% stamped · trust 0.80"
+        assert badge["color"] == "brightgreen"
+
+    def test_low_trust_is_red(self):
+        reports = [ScanReport(enriched=True, overall_trust=0.2)]
+        assert _build_badge(reports)["color"] == "red"
+
+
+class TestScanBadgeCli:
+    def test_badge_to_stdout(self, runner, tmp_path):
+        f = tmp_path / "a.md"
+        f.write_text("# A\n")
+        stamp_file(str(f), agent="claude-code", evidence=["tests pass"])
+        result = runner.invoke(main, ["scan", str(tmp_path), "--badge", "-"])
+        assert result.exit_code == 0
+        badge = json.loads(result.output)
+        assert badge["schemaVersion"] == 1
+        assert "stamped" in badge["message"]
+
+    def test_badge_to_file(self, runner, tmp_path):
+        f = tmp_path / "a.md"
+        f.write_text("# A\n")
+        out = tmp_path / "badge.json"
+        result = runner.invoke(main, ["scan", str(tmp_path), "--badge", str(out)])
+        assert result.exit_code == 0
+        assert json.loads(out.read_text())["label"] == "AKF"
+
+
+class TestSidecarSpecKey:
+    def test_sidecar_is_self_documenting(self, tmp_path):
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"\x00\x01")
+        sc = sidecar.create(str(f), {"claims": [{"c": "binary artifact", "t": 0.8}]})
+        data = json.loads(open(sc).read())
+        assert data["spec"] == "https://akf.dev"
+        assert data["akf"] == "1.0"

--- a/python/tests/test_e2e_certify.py
+++ b/python/tests/test_e2e_certify.py
@@ -714,12 +714,12 @@ class TestCertifyCliFormats:
         result = _run_cli(["certify", str(self.akf_file), "--format", "markdown"])
         assert result.exit_code == 0
         assert "| File |" in result.output
-        assert "| Status |" in result.output or "Status" in result.output
-        assert "|" in result.output
+        assert "| Evidence |" in result.output
+        assert "files certified" in result.output
 
     def test_markdown_shows_pass(self):
         result = _run_cli(["certify", str(self.akf_file), "--format", "markdown", "--min-trust", "0.3"])
-        assert "PASS" in result.output
+        assert "✅" in result.output
 
     def test_summary_shows_counts(self):
         result = _run_cli(["certify", str(self.akf_file), "--format", "summary"])
@@ -904,7 +904,7 @@ class TestCertifyE2ESubprocess:
         rc, out, err = akf_cli("certify", str(d / "report.akf"), "--format", "markdown")
         assert rc == 0
         assert "| File |" in out
-        assert "PASS" in out
+        assert "✅" in out
 
     def test_certify_directory_e2e(self):
         d = Path(TEST_DIR) / "e2e_dir"


### PR DESCRIPTION
## What

The surfaces where **non-users** encounter AKF — every badge, sidecar, and PR comment is how the format spreads.

### `akf scan --badge`
Emits a shields.io endpoint JSON for any repo:

```json
{"schemaVersion": 1, "label": "AKF", "message": "14% stamped · trust 0.76", "color": "brightgreen"}
```

**Dogfooded on this repo**: `.github/akf-badge.json` is committed, the badge is live in the README, and `.github/workflows/akf-badge.yml` refreshes it on every push to main so it never lies.

### Self-documenting sidecars
`.akf.json` sidecars now carry `"spec": "https://akf.dev"`. Formats like `.editorconfig` spread because people see the file in repos and ask what it is — now every sidecar in every public repo answers the question itself.

### PR comment polish (GitHub Action)
`akf certify --format markdown` — what the Action posts on PRs — upgraded from a bare table to a reviewable report: headline verdict (✅ 12/14 files certified · average trust 0.78), **failures sorted first**, an **evidence column** showing what was actually verified (`test_pass`, `human_review`), and a row cap with a truncation note so 500-file repos don't produce unreadable comments.

## Testing
- 7 new tests (badge payloads, CLI stdout/file modes, sidecar spec key)
- 2 existing certify-markdown tests updated to the new format
- Full suite: 1934 passed, 2 skipped