### PR TITLE
chore(release): bump akf (PyPI) and akf-format (npm) to 1.5.0

### DIFF
--- a/python/akf/__init__.py
+++ b/python/akf/__init__.py
@@ -279,7 +279,7 @@ def read(filepath):
         return meta
 
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 __all__ = [
     # Models
     "AKF",

--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -15,7 +15,7 @@ from .trust import compute_all, effective_trust
 
 
 @click.group(invoke_without_command=True)
-@click.version_option(version="1.4.0", prog_name="akf")
+@click.version_option(version="1.5.0", prog_name="akf")
 @click.pass_context
 def main(ctx) -> None:
     """AKF — Agent Knowledge Format CLI."""

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "akf"
-version = "1.4.0"
+version = "1.5.0"
 description = "AKF — Agent Knowledge Format. Lightweight file format for AI-generated knowledge with built-in trust, provenance, and security."
 requires-python = ">=3.9"
 authors = [

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akf-format",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "mcpName": "io.github.HMAKT99/akf",
   "description": "AKF — Agent Knowledge Format SDK for TypeScript",
   "type": "module",


### PR DESCRIPTION
Bumps all four version strings to **1.5.0** for the agent-first release.

## What's in 1.5.0 (since 1.4.0)
- `akf check` — one-line agent trust check with exit codes + 10th MCP tool `check_file` (#113)
- `akf init` — zero-effort default-on setup: git hooks, Claude Code PostToolUse auto-stamp, rules stanzas; new `akf hook` group (#115)
- `akf stamp --preset memory|skill` + decay-aware check (#116)
- `akf scan --badge` — shields.io trust badge; self-documenting sidecars; polished certify markdown for PR comments (#117)
- Agent-first README + docs repositioning (#114)
- Fixes: nested frontmatter destruction on stamp, dropped Claim kwargs, git hook calling nonexistent command, 'reviewed by' evidence classification

After merge: publish to PyPI + npm, cut GitHub release v1.5.0 (akf.dev Download fetches releases/latest).