### PR TITLE
fix(mcp): publish mcp-server-akf to PyPI and repair registry listing

### DIFF
--- a/packages/mcp-server-akf/README.md
+++ b/packages/mcp-server-akf/README.md
@@ -1,13 +1,19 @@
 # mcp-server-akf
 
-MCP (Model Context Protocol) server that exposes 9 AKF tools to AI agents.
-Any MCP-compatible client (Claude Desktop, Cursor, Windsurf, etc.) can stamp,
-validate, audit, and scan files using the Agent Knowledge Format.
+mcp-name: io.github.HMAKT99/akf
+
+MCP (Model Context Protocol) server that exposes 10 AKF tools to AI agents.
+Any MCP-compatible client (Claude Desktop, Claude Code, Cursor, Windsurf, etc.)
+can check, stamp, validate, audit, and scan files using the Agent Knowledge Format.
+
+**A stamp costs ~15 tokens. Re-verifying costs 15,000.** Agents stamp what they
+verify; the next agent calls `check_file` and builds on it instead of redoing
+the work.
 
 ## Installation
 
 ```bash
-pip install ./packages/mcp-server-akf
+pip install mcp-server-akf
 ```
 
 ## Configuration
@@ -46,6 +52,7 @@ Add to `.cursor/mcp.json` in your project root:
 
 | Tool | Description |
 |------|-------------|
+| `check_file` | One-line trust check — can an agent build on this file without re-verifying? (OK / LOW / STALE / UNSTAMPED) |
 | `create_claim` | Create an AKF claim with trust metadata |
 | `validate_file` | Validate an `.akf` file against the spec |
 | `scan_file` | Security scan any file for AKF metadata |

--- a/packages/mcp-server-akf/pyproject.toml
+++ b/packages/mcp-server-akf/pyproject.toml
@@ -4,16 +4,33 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-server-akf"
-version = "0.1.0"
-description = "MCP server for Agent Knowledge Format (AKF)"
+version = "1.5.0"
+description = "MCP server for AKF — check, stamp, and audit trust metadata on any file"
+readme = "README.md"
+license = { text = "MIT" }
+authors = [{ name = "AKF Project" }]
+keywords = ["mcp", "model-context-protocol", "akf", "trust", "provenance", "ai-agents"]
 requires-python = ">=3.10"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Libraries",
+]
 dependencies = [
-    "akf>=1.0.0",
+    "akf>=1.5.0",
     "mcp>=1.0.0",
 ]
+
+[project.urls]
+Homepage = "https://akf.dev"
+Repository = "https://github.com/HMAKT99/AKF"
+Documentation = "https://github.com/HMAKT99/AKF/tree/main/packages/mcp-server-akf"
 
 [project.scripts]
 mcp-server-akf = "mcp_server_akf.server:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]
+
+[tool.setuptools]
+packages = ["mcp_server_akf"]

--- a/packages/mcp-server-akf/server.json
+++ b/packages/mcp-server-akf/server.json
@@ -1,18 +1,19 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.HMAKT99/akf",
-  "description": "The AI native file format. EXIF for AI — trust, provenance, and compliance for 20+ formats.",
+  "description": "Trust metadata for AI agents — check files before building on them, stamp verified work.",
   "repository": {
     "url": "https://github.com/HMAKT99/AKF",
     "source": "github",
     "subfolder": "packages/mcp-server-akf"
   },
-  "version": "1.2.9",
+  "version": "1.5.0",
+  "websiteUrl": "https://akf.dev",
   "packages": [
     {
-      "registryType": "npm",
-      "identifier": "akf-format",
-      "version": "1.2.9",
+      "registryType": "pypi",
+      "identifier": "mcp-server-akf",
+      "version": "1.5.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## What

The official MCP registry listing for `io.github.HMAKT99/akf` pointed at **npm `akf-format`** — a package that contains no MCP server. Anyone who discovered AKF through the registry and installed it got nothing runnable. This likely suppressed adoption through the single highest-intent discovery channel.

## Fixed

- **`mcp-server-akf` is now on PyPI** at 1.5.0: https://pypi.org/project/mcp-server-akf/1.5.0/ — real `pip install mcp-server-akf`, depends on `akf>=1.5.0`, README carries the `mcp-name` ownership marker
- **`server.json`** repointed to the PyPI package, bumped to 1.5.0, agent-first description — **republished to registry.modelcontextprotocol.io** (verified live)
- README updated: 10 tools with `check_file` first, correct install command

## Verification
```console
$ curl -s 'https://registry.modelcontextprotocol.io/v0/servers/io.github.HMAKT99%2Fakf'
1.5.0 | Trust metadata for AI agents — check files before building on them, stamp verified work. | pypi:mcp-server-akf
```