### PR TITLE
feat(plugins): Claude Code plugin — auto-stamp hook + check skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "akf",
+  "owner": {
+    "name": "HMAKT99",
+    "url": "https://github.com/HMAKT99"
+  },
+  "metadata": {
+    "description": "Trust metadata for AI-generated files — the check-before-you-trust loop for Claude Code."
+  },
+  "plugins": [
+    {
+      "name": "akf",
+      "source": "./plugins/akf",
+      "description": "Trust metadata for AI-generated files — auto-stamps what Claude Code writes, and checks trust before building on existing work. A stamp costs ~15 tokens; re-verifying costs 15,000.",
+      "author": { "name": "HMAKT99" },
+      "homepage": "https://akf.dev",
+      "repository": "https://github.com/HMAKT99/AKF",
+      "license": "MIT",
+      "keywords": ["trust", "provenance", "ai-agents", "verification"],
+      "category": "productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ AKF works where AI agents work. Drop a config file, and every AI-generated file 
 
 | Agent | How it works |
 |-------|-------------|
-| **Claude Code** | Reads `CLAUDE.md` — stamps every file it creates with confidence and evidence |
+| **Claude Code** | Plugin: `/plugin marketplace add HMAKT99/AKF` → `/plugin install akf` — auto-stamp hook + check skill. Or reads `CLAUDE.md` |
 | **Cursor** | Reads `.cursorrules` — stamps AI edits before you review |
 | **Windsurf** | Reads `.windsurfrules` — stamps AI edits with trust metadata |
 | **GitHub Copilot** | Reads `.github/copilot-instructions.md` (native) + shell hook for CLI |

--- a/plugins/akf/.claude-plugin/plugin.json
+++ b/plugins/akf/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "akf",
+  "description": "Trust metadata for AI-generated files — auto-stamps what Claude Code writes, and checks trust before building on existing work.",
+  "version": "1.5.0",
+  "author": { "name": "HMAKT99" },
+  "homepage": "https://akf.dev",
+  "repository": "https://github.com/HMAKT99/AKF",
+  "license": "MIT"
+}

--- a/plugins/akf/hooks/hooks.json
+++ b/plugins/akf/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/autostamp.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/akf/scripts/autostamp.sh
+++ b/plugins/akf/scripts/autostamp.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# PostToolUse auto-stamp: reads the hook payload from stdin and stamps the
+# written file with AKF trust metadata. A provenance hook must never block
+# the agent — always exits 0, silent when akf isn't installed.
+if command -v akf >/dev/null 2>&1; then
+  akf hook claude 2>/dev/null || true
+elif command -v python3 >/dev/null 2>&1; then
+  python3 -m akf hook claude 2>/dev/null || true
+fi
+exit 0

--- a/plugins/akf/skills/akf/SKILL.md
+++ b/plugins/akf/skills/akf/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: akf
+description: Trust metadata for files, memories, and skills — check before you trust, stamp what you verify. Use before building on existing files, after completing verified work, and when handling agent memories or downloaded skills.
+akf:
+  v: "1.0"
+  claims:
+    - c: Trust metadata for plugins/akf/skills/akf/SKILL.md
+      t: 0.7
+      id: a569fafc
+      src: unspecified
+      tier: 3
+      ver: false
+      ai: true
+      decay: 365
+      kind: skill
+      evidence:
+        - type: human_review
+          detail: "reviewed by @HMAKT99, claude plugin validate passed"
+          at: "2026-07-04T07:38:00.697134+00:00"
+  id: "akf-fc4aaa7b1cff"
+  agent: "claude-code"
+  at: "2026-07-04T07:38:00.698185+00:00"
+  label: public
+  inherit: true
+  ext: false
+  hash: "sha256:68a8c0fdc8d95249"
+  sv: "1.1"
+---
+
+# AKF — Agent Knowledge Format
+
+Leave trust metadata on everything you produce, and check it on everything you consume. Stamps are notes agents leave for the next agent (including future you): what was done, what was verified, how much to trust it now. A stamp costs ~15 tokens; re-verifying costs 15,000.
+
+This plugin auto-stamps files you write via a PostToolUse hook. Your job is the read path and the evidence.
+
+## Before building on an existing file
+
+```bash
+akf check <file>
+```
+
+- `OK` (exit 0) — fresh stamp with verified evidence. Build on it; skip re-verification.
+- `LOW` (exit 1) — stamped but unverified, or trust decayed. Verify before trusting.
+- `STALE` (exit 1) — file modified after stamping, or a local dependency it imports changed (`reason=dependency_changed`). Re-verify.
+- `UNSTAMPED` (exit 2) — no provenance. Treat as unverified.
+
+## After completing verified work
+
+Stamp with the strongest evidence you actually observed:
+
+```bash
+akf stamp report.py --agent claude-code --evidence "42/42 tests passed"
+```
+
+Evidence is auto-classified and drives trust: test runs and human review clear the trust bar; bare stamps stay LOW by design. **Only claim evidence you observed** — a stamp saying tests passed when they didn't poisons every agent that trusts it.
+
+## Memories and skills
+
+```bash
+akf stamp memory/facts.md --preset memory   # 30-day trust decay — stale memories go LOW automatically
+akf check downloaded-skill.md               # STALE = not the file the publisher stamped
+```
+
+## Setup
+
+If `akf` isn't installed: `pip install akf` (or `pipx install akf`), then `akf init` in the project to wire git hooks. `akf doctor` diagnoses PATH issues.


### PR DESCRIPTION
## What

Native Claude Code plugin distribution:

```
/plugin marketplace add HMAKT99/AKF
/plugin install akf
```

gives any Claude Code user:
- **PostToolUse auto-stamp hook** (Write|Edit) — every file Claude writes gets stamped via `akf hook claude`; silent and non-blocking, no-ops when akf isn't installed
- **`akf` skill** — the check→stamp protocol, evidence honesty rules, memory decay + skill supply-chain checks (adapted from the agentskills.io skill)

Layout per the plugins reference: `.claude-plugin/marketplace.json` at repo root, plugin under `plugins/akf/` with `plugin.json`, `skills/`, `hooks/hooks.json`, `${CLAUDE_PLUGIN_ROOT}`-relative script.

README: Claude Code row now leads with the plugin install.

## Verification
- `claude plugin validate .` → **Validation passed** (zero warnings)
- All JSON parses; hook script exits 0 in all paths; skill file self-stamped (`--preset skill`)