### PR TITLE
feat(check): pin cited sources — STALE on source_changed

### DIFF
--- a/python/akf/check.py
+++ b/python/akf/check.py
@@ -197,6 +197,15 @@ def check_file(filepath: str, threshold: float = 0.6) -> CheckResult:
         if changed_deps(filepath, recorded_deps):
             return CheckResult(status="STALE", exit_code=1, reason="dependency_changed", **base)
 
+    # Cited-source staleness (#129): a claim pinned its source's content hash
+    # at stamp time; if the source moved, the claim stands on drifted ground.
+    from .deps import hash_source
+    src_dir = os.path.dirname(os.path.abspath(filepath))
+    for claim in unit.claims:
+        pinned = getattr(claim, "src_hash", None)
+        if pinned and hash_source(claim.source, src_dir) != pinned:
+            return CheckResult(status="STALE", exit_code=1, reason="source_changed", **base)
+
     if overall < threshold:
         return CheckResult(status="LOW", exit_code=1, reason="below_threshold", **base)
 

--- a/python/akf/deps.py
+++ b/python/akf/deps.py
@@ -92,6 +92,24 @@ def resolve_local_deps(filepath: str) -> Dict[str, str]:
     return deps
 
 
+def hash_source(source: Optional[str], base_dir: str) -> Optional[str]:
+    """Content hash for a claim's cited source, when it resolves locally (#129).
+
+    Accepts absolute paths or paths relative to the stamped file's directory.
+    Returns None for URLs, placeholders like "unspecified", or anything that
+    doesn't resolve to a readable file — pinning is best-effort by design.
+    """
+    if not source or source == "unspecified" or "://" in source:
+        return None
+    path = source if os.path.isabs(source) else os.path.join(base_dir, source)
+    if not os.path.isfile(path):
+        return None
+    try:
+        return _hash_file(path)
+    except OSError:
+        return None
+
+
 def changed_deps(filepath: str, recorded: Dict[str, str]) -> list:
     """Return the recorded dependencies whose content no longer matches."""
     base_dir = os.path.dirname(os.path.abspath(filepath))

--- a/python/akf/models.py
+++ b/python/akf/models.py
@@ -451,6 +451,9 @@ class Claim(BaseModel):
     confidence: float = Field(ge=0.0, le=1.0, validation_alias=AliasChoices("t", "confidence"))
     id: Optional[str] = None
     source: Optional[str] = Field(None, validation_alias=AliasChoices("src", "source"))
+    # Content hash of the cited source at stamp time (issue #129): lets
+    # `akf check` flag STALE when the source a claim cites has moved.
+    src_hash: Optional[str] = None
     uri: Optional[str] = None
     authority_tier: Optional[int] = Field(
         None, ge=1, le=5, validation_alias=AliasChoices("tier", "authority_tier")

--- a/python/akf/stamp.py
+++ b/python/akf/stamp.py
@@ -13,6 +13,7 @@ Usage:
               trust_score=0.92)
 """
 
+import os
 import re
 from datetime import datetime, timezone
 from typing import List, Optional, Union
@@ -230,10 +231,19 @@ def stamp_file(
 
     # Record first-degree local import hashes (Python files) so `akf check`
     # can flag staleness when a dependency changes, not just this file (#124).
-    from .deps import resolve_local_deps
+    from .deps import resolve_local_deps, hash_source
     dep_hashes = resolve_local_deps(filepath)
     if dep_hashes:
         unit = unit.model_copy(update={"meta": {**(unit.meta or {}), "deps": dep_hashes}})
+
+    # Pin cited sources (#129): when a claim's src resolves to a local file,
+    # record its content hash so `akf check` can flag source_changed.
+    base_dir = os.path.dirname(os.path.abspath(filepath))
+    pinned = []
+    for claim in unit.claims:
+        h = hash_source(claim.source, base_dir)
+        pinned.append(claim.model_copy(update={"src_hash": h}) if h else claim)
+    unit = unit.model_copy(update={"claims": pinned})
 
     # Embed into the file using universal format layer
     from .universal import embed as _embed

--- a/python/tests/test_deps.py
+++ b/python/tests/test_deps.py
@@ -78,3 +78,54 @@ class TestDependencyStaleness:
     def test_deps_recorded_in_stamp_meta(self, pkg):
         unit = stamp_file(str(pkg), agent="claude-code")
         assert "helper.py" in unit.meta["deps"]
+
+
+class TestSourceHashAttestation:
+    """#129 — claims pin their cited source's content at stamp time."""
+
+    def _freeze_mtime(self, path):
+        past = time.time() - 1
+        os.utime(path, (past, past))
+
+    def test_local_source_pinned_and_checked(self, tmp_path):
+        src = tmp_path / "data.csv"
+        src.write_text("q1,42\n")
+        report = tmp_path / "report.md"
+        report.write_text("# Q1 report\n")
+        from akf.stamp import stamp_file
+        unit = stamp_file(str(report), agent="claude-code",
+                          claims=["Q1 revenue was 42"], source="data.csv",
+                          evidence=["tests pass"])
+        assert unit.claims[0].src_hash and unit.claims[0].src_hash.startswith("sha256:")
+        assert check_file(str(report)).status == "OK"
+
+        # The cited source moves; report.md itself is untouched.
+        src.write_text("q1,999\n")
+        self._freeze_mtime(report)
+        result = check_file(str(report))
+        assert result.status == "STALE"
+        assert result.reason == "source_changed"
+
+    def test_deleted_source_is_stale(self, tmp_path):
+        src = tmp_path / "notes.txt"
+        src.write_text("facts\n")
+        f = tmp_path / "summary.md"
+        f.write_text("# Summary\n")
+        from akf.stamp import stamp_file
+        stamp_file(str(f), agent="a", claims=["summary of notes"],
+                   source="notes.txt", evidence=["tests pass"])
+        src.unlink()
+        self._freeze_mtime(f)
+        assert check_file(str(f)).reason == "source_changed"
+
+    def test_url_and_placeholder_sources_not_pinned(self, tmp_path):
+        f = tmp_path / "doc.md"
+        f.write_text("# Doc\n")
+        from akf.stamp import stamp_file
+        u1 = stamp_file(str(f), agent="a", claims=["from the web"],
+                        source="https://example.com/page")
+        assert u1.claims[0].src_hash is None
+        f2 = tmp_path / "doc2.md"
+        f2.write_text("# Doc2\n")
+        u2 = stamp_file(str(f2), agent="a")  # default source: unspecified
+        assert u2.claims[0].src_hash is None


### PR DESCRIPTION
First of the v1.6 "from claimed to checkable" series. Closes #129.

Claims citing a resolvable local file record its content hash (`Claim.src_hash`) at stamp time; `akf check` flips `STALE reason=source_changed` when the source's content no longer matches — the file is untouched, but the ground it cites has moved. Retires the "has this source changed since I captured it" re-read class.

- Reuses the #126 hashing machinery (`deps.hash_source`)
- Best-effort: URLs and `unspecified` sources aren't pinned (network pinning deferred as opt-in)
- Additive schema: optional field, wire-compatible

Tests: 3 new (pin + drift → STALE, deleted source → STALE, URL/placeholder not pinned); full suite 1953 passed.

Credit: Mike Czerwinski.