### PR TITLE
feat(check): receipt-strength scaling for evidence weight

### DIFF
--- a/python/akf/check.py
+++ b/python/akf/check.py
@@ -109,17 +109,43 @@ def _evidence_types(unit: AKF) -> List[str]:
     return types
 
 
+def _evidence_floor(ev) -> Optional[int]:
+    """Tier floor for one piece of evidence, scaled by receipt strength (#125).
+
+    Bare receipts keep their type's floor (no regression). Receipts whose
+    parsed metrics reveal weakness — a partial pass fraction or coverage
+    under 30% — drop to the weak floor: a green check from a trivial suite
+    shouldn't outrank one from a real one. Replayable evidence keeps the
+    strong floor: a falsifiable claim can at least be re-checked.
+    """
+    ev_type = getattr(ev, "type", None)
+    base = _EVIDENCE_TIER_FLOOR.get(ev_type)
+    if getattr(ev, "replay", None):
+        return 2 if base is None else min(base, 2)
+    if base is None:
+        return None
+    if ev_type in ("test_pass", "ci_pass"):
+        m = getattr(ev, "metrics", None) or {}
+        total, passed = m.get("tests_total"), m.get("tests_passed")
+        if total and passed is not None and passed < total:
+            return 3
+        cov = m.get("coverage")
+        if cov is not None and cov < 0.3:
+            return 3
+    return base
+
+
 def _claim_score(claim: Claim, age_days: float = 0) -> float:
     """Effective trust with evidence-aware authority and temporal decay.
 
     Verification receipts (tests, type checks, human review) floor the
-    authority tier — see _EVIDENCE_TIER_FLOOR. Stamp age drives decay for
-    claims with a decay_half_life (e.g. memory stamps).
+    authority tier — see _EVIDENCE_TIER_FLOOR and _evidence_floor. Stamp
+    age drives decay for claims with a decay_half_life (memory stamps).
     """
     floors = [
-        _EVIDENCE_TIER_FLOOR[ev.type]
+        floor
         for ev in (claim.evidence or [])
-        if getattr(ev, "type", None) in _EVIDENCE_TIER_FLOOR
+        if (floor := _evidence_floor(ev)) is not None
     ]
     if floors:
         tier = claim.authority_tier if claim.authority_tier is not None else 3

--- a/python/akf/models.py
+++ b/python/akf/models.py
@@ -205,6 +205,10 @@ class Evidence(BaseModel):
     timestamp: Optional[str] = Field(None, validation_alias=AliasChoices("at", "timestamp"))
     tool: Optional[str] = None
     replay: Optional[Replay] = None
+    # Parsed receipt strength (#125): e.g. {"coverage": 0.85,
+    # "tests_passed": 42, "tests_total": 42}. Lets trust weighting scale
+    # with how strong the receipt is, not just its type.
+    metrics: Optional[Dict[str, float]] = None
 
     def to_dict(self, compact: bool = False) -> dict:
         d = _strip_none(self.model_dump())

--- a/python/akf/stamp.py
+++ b/python/akf/stamp.py
@@ -52,11 +52,30 @@ _EVIDENCE_PATTERNS = [
 ]
 
 
+def _parse_metrics(s: str) -> Optional[dict]:
+    """Extract receipt strength from an evidence string (#125).
+
+    Recognizes "42/42 tests passed" (pass fraction) and
+    "coverage: 85%" / "85% coverage" (coverage ratio).
+    """
+    metrics: dict = {}
+    frac = re.search(r"(\d+)\s*/\s*(\d+)\s*tests?", s.lower())
+    if frac:
+        passed, total = int(frac.group(1)), int(frac.group(2))
+        metrics["tests_passed"] = float(passed)
+        metrics["tests_total"] = float(total)
+    cov = re.search(r"coverage[:\s]+(\d{1,3})\s*%|(\d{1,3})\s*%\s+coverage", s.lower())
+    if cov:
+        metrics["coverage"] = int(cov.group(1) or cov.group(2)) / 100.0
+    return metrics or None
+
+
 def parse_evidence_string(s: str) -> Evidence:
     """Parse a plain-text evidence string into an Evidence object.
 
     Auto-detects type from common patterns (test_pass, type_check,
-    lint_clean, ci_pass, human_review). Falls back to 'other'.
+    lint_clean, ci_pass, human_review) and receipt strength metrics.
+    Falls back to 'other'.
     """
     lower = s.lower()
     ev_type = "other"
@@ -69,6 +88,7 @@ def parse_evidence_string(s: str) -> Evidence:
         type=ev_type,
         detail=s,
         timestamp=datetime.now(timezone.utc).isoformat(),
+        metrics=_parse_metrics(s),
     )
 
 

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -137,3 +137,49 @@ class TestCheckCmd:
         payload = json.loads(result.output)
         assert payload["status"] == "OK"
         assert payload["agent"] == "claude-code"
+
+
+class TestReceiptStrengthScaling:
+    """#125 — evidence weight scales with receipt strength, additively."""
+
+    def test_bare_tests_pass_unchanged(self, tmp_path):
+        # The documented hero flow must not regress.
+        p = tmp_path / "hero.md"
+        p.write_text("# H\n")
+        stamp_file(str(p), agent="claude-code", evidence=["tests pass"])
+        assert check_file(str(p)).status == "OK"
+
+    def test_full_pass_fraction_keeps_strong_floor(self, tmp_path):
+        p = tmp_path / "full.md"
+        p.write_text("# F\n")
+        stamp_file(str(p), agent="claude-code", evidence=["42/42 tests passed"])
+        assert check_file(str(p)).status == "OK"
+
+    def test_partial_pass_fraction_weakens(self, tmp_path):
+        p = tmp_path / "partial.md"
+        p.write_text("# P\n")
+        stamp_file(str(p), agent="claude-code", evidence=["40/42 tests passed"])
+        result = check_file(str(p))
+        assert result.status == "LOW"
+
+    def test_low_coverage_weakens(self, tmp_path):
+        p = tmp_path / "lowcov.md"
+        p.write_text("# L\n")
+        stamp_file(str(p), agent="claude-code",
+                   evidence=["tests pass, coverage: 12%"])
+        assert check_file(str(p)).status == "LOW"
+
+    def test_high_coverage_keeps_strong_floor(self, tmp_path):
+        p = tmp_path / "hicov.md"
+        p.write_text("# H\n")
+        stamp_file(str(p), agent="claude-code",
+                   evidence=["tests pass, coverage: 85%"])
+        assert check_file(str(p)).status == "OK"
+
+    def test_replayable_evidence_keeps_strong_floor(self, tmp_path):
+        p = tmp_path / "rep.md"
+        p.write_text("# R\n")
+        stamp_file(str(p), agent="claude-code", replay="true")
+        # replay recipe of "true" classifies as type other, but replayability
+        # itself earns the strong floor
+        assert check_file(str(p)).status == "OK"


### PR DESCRIPTION
Third of the v1.6 "from claimed to checkable" series. Closes #125.

**The gap:** a stamp with one trivial test earned the same `test_pass` floor as a comprehensive suite — a rubber stamp.

**Additive fix** (documented flows do not regress):
- Evidence strings now parse **receipt strength** into `Evidence.metrics`: pass fractions (`42/42 tests passed`) and coverage (`coverage: 85%`)
- Partial pass fractions and coverage <30% drop to the weak floor → `LOW`
- Coverage ≥30% and full fractions keep the strong floor
- **Replayable evidence keeps the strong floor regardless of type** — a falsifiable claim can at least be re-checked with `akf replay` (this is the #128 synergy: the principled answer to stamp inflation is falsifiability, and this wires the incentive)
- Bare `"tests pass"` unchanged — hero-flow regression guard is an explicit test

Tests: 6 new incl. the no-regression guard; full suite 1969 passed.

Credit: **Dipankar Sarkar** for the original rubber-stamp observation on the launch post.