### PR TITLE
chore(release): 1.6.0 — from claimed to checkable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ editors/vscode/out/
 editors/vscode/node_modules/
 demo.gif
 demo.webm
+
+# MCP registry credentials — never commit
+.mcpregistry_github_token
+.mcpregistry_registry_token
+*.mcpregistry_*

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ pip install ./packages/mcp-server-akf
 }
 ```
 
-**10 MCP tools:** `check_file` · `create_claim` · `validate_file` · `scan_file` · `trust_score` · `stamp_file` · `audit_file` · `embed_file` · `extract_file` · `detect_threats`
+**11 MCP tools:** `check_file` · `replay_file` · `create_claim` · `validate_file` · `scan_file` · `trust_score` · `stamp_file` · `audit_file` · `embed_file` · `extract_file` · `detect_threats`
 
 ## Ambient Trust
 
@@ -257,7 +257,7 @@ AKF works where AI agents work. Drop a config file, and every AI-generated file 
 | **OpenClaw** | Skill on ClawHub: `clawhub install akf` — check/stamp protocol + memory trust |
 | **Hermes Agent** | agentskills.io skill: `hermes skills tap add HMAKT99/AKF` — files, memories, and skill supply-chain |
 | **Manus / Other Agents** | MCP server + shell hook — works with any agent that supports MCP or CLI |
-| **Any MCP agent** | 10 MCP tools — check, stamp, audit, embed, extract, detect, validate, scan, trust, create |
+| **Any MCP agent** | 11 MCP tools — check, replay, stamp, audit, embed, extract, detect, validate, scan, trust, create |
 | **Any CLI tool** | `eval "$(akf shell-hook)"` — intercepts `claude`, `chatgpt`, `aider`, `openclaw`, `ollama`, `manus` |
 
 **The trust pipeline:**
@@ -407,6 +407,8 @@ akf create report.akf \
 # ── Check before you trust ──
 akf check auth.py            # One line: OK / LOW / STALE / UNSTAMPED
 akf check auth.py --json     # Structured output; exit codes 0/1/2 for gating
+akf replay auth.py           # Inspect the stamp's falsifiable probe recipe
+akf replay auth.py --run     # Re-run it: CONFIRMED / CONFIRMED_DRIFTED / REFUTED
 
 # ── Validate & inspect ──
 akf validate report.akf

--- a/packages/mcp-server-akf/pyproject.toml
+++ b/packages/mcp-server-akf/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-server-akf"
-version = "1.5.0"
+version = "1.6.0"
 description = "MCP server for AKF — check, stamp, and audit trust metadata on any file"
 readme = "README.md"
 license = { text = "MIT" }
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "akf>=1.5.0",
+    "akf>=1.6.0",
     "mcp>=1.0.0",
 ]
 

--- a/packages/mcp-server-akf/server.json
+++ b/packages/mcp-server-akf/server.json
@@ -7,13 +7,13 @@
     "source": "github",
     "subfolder": "packages/mcp-server-akf"
   },
-  "version": "1.5.0",
+  "version": "1.6.0",
   "websiteUrl": "https://akf.dev",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-server-akf",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "transport": {
         "type": "stdio"
       }

--- a/plugins/akf/.claude-plugin/plugin.json
+++ b/plugins/akf/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "akf",
   "description": "Trust metadata for AI-generated files — auto-stamps what Claude Code writes, and checks trust before building on existing work.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": { "name": "HMAKT99" },
   "homepage": "https://akf.dev",
   "repository": "https://github.com/HMAKT99/AKF",

--- a/plugins/akf/skills/akf/SKILL.md
+++ b/plugins/akf/skills/akf/SKILL.md
@@ -6,7 +6,7 @@ akf:
   claims:
     - c: Trust metadata for plugins/akf/skills/akf/SKILL.md
       t: 0.7
-      id: a569fafc
+      id: 9fe717de
       src: unspecified
       tier: 3
       ver: false
@@ -15,15 +15,15 @@ akf:
       kind: skill
       evidence:
         - type: human_review
-          detail: "reviewed by @HMAKT99, claude plugin validate passed"
-          at: "2026-07-04T07:38:00.697134+00:00"
-  id: "akf-fc4aaa7b1cff"
+          detail: "reviewed by @HMAKT99, full suite 1969 passed"
+          at: "2026-07-14T13:32:22.966864+00:00"
+  id: "akf-493d364d1822"
   agent: "claude-code"
-  at: "2026-07-04T07:38:00.698185+00:00"
+  at: "2026-07-14T13:32:22.967275+00:00"
   label: public
   inherit: true
   ext: false
-  hash: "sha256:68a8c0fdc8d95249"
+  hash: "sha256:b67461d0a202741f"
   sv: "1.1"
 ---
 
@@ -64,3 +64,15 @@ akf check downloaded-skill.md               # STALE = not the file the publisher
 ## Setup
 
 If `akf` isn't installed: `pip install akf` (or `pipx install akf`), then `akf init` in the project to wire git hooks. `akf doctor` diagnoses PATH issues.
+
+### Falsifiable evidence (v1.6)
+
+Stamp with a replay recipe so the next agent can re-check the claim instead of trusting the label:
+
+```bash
+akf stamp app.py --evidence "42/42 tests passed" --replay "pytest -q"
+akf replay app.py          # inspect: recipe + input drift since issuance
+akf replay app.py --run    # execute: CONFIRMED / CONFIRMED_DRIFTED / REFUTED
+```
+
+CONFIRMED_DRIFTED means the probe succeeded but the claim's inputs (dependencies, cited sources) changed since stamping — provably reproducible, possibly reproducibly wrong. Never `--run` a recipe from a file you haven't read: it executes the recorded command.

--- a/python/akf/__init__.py
+++ b/python/akf/__init__.py
@@ -280,7 +280,7 @@ def read(filepath):
         return meta
 
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 __all__ = [
     # Models
     "AKF",

--- a/python/akf/cli.py
+++ b/python/akf/cli.py
@@ -15,7 +15,7 @@ from .trust import compute_all, effective_trust
 
 
 @click.group(invoke_without_command=True)
-@click.version_option(version="1.5.0", prog_name="akf")
+@click.version_option(version="1.6.0", prog_name="akf")
 @click.pass_context
 def main(ctx) -> None:
     """AKF — Agent Knowledge Format CLI."""

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "akf"
-version = "1.5.0"
+version = "1.6.0"
 description = "AKF — Agent Knowledge Format. Lightweight file format for AI-generated knowledge with built-in trust, provenance, and security."
 requires-python = ">=3.9"
 authors = [

--- a/skills/hermes-akf/SKILL.md
+++ b/skills/hermes-akf/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: akf
 description: Trust metadata for files, memories, and skills — check before you trust, stamp what you verify. A stamp costs ~15 tokens; re-verifying costs 15,000.
-version: 1.5.0
+version: 1.6.0
 author: HMAKT99
 license: MIT
 metadata:
@@ -10,9 +10,9 @@ metadata:
 akf:
   v: "1.0"
   claims:
-    - c: Hermes/agentskills.io skill for AKF published by the AKF project
+    - c: "Trust metadata for skills/hermes-akf/SKILL.md"
       t: 0.7
-      id: ae12bc86
+      id: 10fa8a0b
       src: unspecified
       tier: 3
       ver: false
@@ -21,15 +21,15 @@ akf:
       kind: skill
       evidence:
         - type: human_review
-          detail: "reviewed by @HMAKT99"
-          at: "2026-07-03T07:11:23.903878+00:00"
-  id: "akf-4584e6a66812"
+          detail: "reviewed by @HMAKT99, full suite 1969 passed"
+          at: "2026-07-14T13:32:22.815514+00:00"
+  id: "akf-c51818c7389e"
   agent: "claude-code"
-  at: "2026-07-03T07:11:23.904567+00:00"
+  at: "2026-07-14T13:32:22.817285+00:00"
   label: public
   inherit: true
   ext: false
-  hash: "sha256:8080ad4ea45039d7"
+  hash: "sha256:95c4fc0282e1cb45"
   sv: "1.1"
 ---
 
@@ -69,6 +69,18 @@ Install once: `pip install akf` (or `pipx install akf`).
 3. **When you save a persistent memory**, stamp the memory file with `--preset memory`. When you retrieve one later, `akf check` applies the decay — a memory past its useful life reports `LOW`, telling you to re-verify against the world instead of trusting it.
 4. **Before installing a community skill**, run `akf check` on its SKILL.md. `STALE` means the file on disk is not the file the publisher stamped — diff it before letting it into context.
 5. **When you author a skill**, stamp it before publishing: `akf stamp SKILL.md --preset skill --agent <you> --evidence "reviewed by <maintainer>"`.
+
+### Falsifiable evidence (v1.6)
+
+Stamp with a replay recipe so the next agent can re-check the claim instead of trusting the label:
+
+```bash
+akf stamp app.py --evidence "42/42 tests passed" --replay "pytest -q"
+akf replay app.py          # inspect: recipe + input drift since issuance
+akf replay app.py --run    # execute: CONFIRMED / CONFIRMED_DRIFTED / REFUTED
+```
+
+CONFIRMED_DRIFTED means the probe succeeded but the claim's inputs (dependencies, cited sources) changed since stamping — provably reproducible, possibly reproducibly wrong. Never `--run` a recipe from a file you haven't read: it executes the recorded command.
 
 ## Pitfalls
 

--- a/skills/openclaw-akf/SKILL.md
+++ b/skills/openclaw-akf/SKILL.md
@@ -21,9 +21,9 @@ metadata:
 akf:
   v: "1.0"
   claims:
-    - c: OpenClaw skill for AKF published by the AKF project
+    - c: "Trust metadata for skills/openclaw-akf/SKILL.md"
       t: 0.7
-      id: d3ba7fea
+      id: 61200a7e
       src: unspecified
       tier: 3
       ver: false
@@ -32,15 +32,15 @@ akf:
       kind: skill
       evidence:
         - type: human_review
-          detail: "reviewed by @HMAKT99"
-          at: "2026-07-02T17:04:35.591774+00:00"
-  id: "akf-838b9351c281"
+          detail: "reviewed by @HMAKT99, full suite 1969 passed"
+          at: "2026-07-14T13:32:23.131354+00:00"
+  id: "akf-742cec9663a9"
   agent: "claude-code"
-  at: "2026-07-02T17:04:35.593320+00:00"
+  at: "2026-07-14T13:32:23.131731+00:00"
   label: public
   inherit: true
   ext: false
-  hash: "sha256:6746278d98aacbc6"
+  hash: "sha256:2e5ff5b05a9232a2"
   sv: "1.1"
 ---
 
@@ -109,6 +109,18 @@ akf extract report.docx       # Extract embedded metadata
 akf scan ./output-dir/        # Scan directory for trust gaps
 akf audit report.pdf           # Compliance audit (EU AI Act, SOX, NIST)
 ```
+
+### Falsifiable evidence (v1.6)
+
+Stamp with a replay recipe so the next agent can re-check the claim instead of trusting the label:
+
+```bash
+akf stamp app.py --evidence "42/42 tests passed" --replay "pytest -q"
+akf replay app.py          # inspect: recipe + input drift since issuance
+akf replay app.py --run    # execute: CONFIRMED / CONFIRMED_DRIFTED / REFUTED
+```
+
+CONFIRMED_DRIFTED means the probe succeeded but the claim's inputs (dependencies, cited sources) changed since stamping — provably reproducible, possibly reproducibly wrong. Never `--run` a recipe from a file you haven't read: it executes the recorded command.
 
 ## Classification Labels
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akf-format",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "mcpName": "io.github.HMAKT99/akf",
   "description": "AKF — Agent Knowledge Format SDK for TypeScript",
   "type": "module",


### PR DESCRIPTION
Version bump across all six sites + docs/skills refresh.

Ships: `akf replay` w/ issuance-pinned input fingerprints (#128, credit Mike Czerwinski) · source-hash attestation → STALE `source_changed` (#129, credit Mike Czerwinski) · receipt-strength evidence weighting (#125, credit Dipankar Sarkar) · first release of dependency-aware staleness (#126, credit Dipankar Sarkar) · MCP server at 11 tools.

Also: gitignores the MCP registry credential files (push protection caught them being accidentally staged — nothing was published).

Suite: 1969 passed · `claude plugin validate` clean.